### PR TITLE
Replace html5ever_elixir with meeseeks_html5ever (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then run `mix get.deps`.
 
 ## Dependencies
 
-Meeseeks depends on [html5ever](https://github.com/servo/html5ever) via the [html5ever NIF](https://github.com/hansihe/html5ever_elixir).
+Meeseeks depends on [html5ever](https://github.com/servo/html5ever) via [meeseeks_html5ever](https://github.com/mischov/meeseeks_html5ever).
 
 Because html5ever is a Rust library, you will need to have the Rust compiler [installed](https://www.rust-lang.org/en-US/install.html).
 

--- a/lib/meeseeks.ex
+++ b/lib/meeseeks.ex
@@ -21,7 +21,7 @@ defmodule Meeseeks do
   ## Dependencies
 
   Meeseeks depends on [html5ever](https://github.com/servo/html5ever) via
-  the [html5ever NIF](https://github.com/hansihe/html5ever_elixir).
+  [meeseeks_html5ever](https://github.com/mischov/meeseeks_html5ever).
 
   Because html5ever is a Rust library, you will need to have the Rust
   compiler [installed](https://www.rust-lang.org/en-US/install.html).

--- a/lib/meeseeks/document.ex
+++ b/lib/meeseeks/document.ex
@@ -24,7 +24,7 @@ defmodule Meeseeks.Document do
                             {"p", [], ["3"]}]}]}]}
   {...}
 
-  iex> document = Meeseeks.Document(tuple_tree)
+  iex> document = Meeseeks.Parser.parse(tuple_tree)
   %Meeseeks.Document{
     id_counter: 12,
     roots: [1],
@@ -58,8 +58,7 @@ defmodule Meeseeks.Document do
   """
 
   alias Meeseeks.Document
-  alias Meeseeks.Document.{Comment, Data, Doctype, Element, Node, Text}
-  alias Meeseeks.TupleTree
+  alias Meeseeks.Document.{Element, Node}
 
   defstruct id_counter: nil, roots: [], nodes: %{}
 
@@ -68,133 +67,6 @@ defmodule Meeseeks.Document do
   @type t :: %Document{id_counter: node_id | nil,
                        roots: [node_id],
                        nodes: %{optional(node_id) => node_t}}
-
-  # Build
-
-  @doc """
-  Creates a document from a `Meeseeks.TupleTree`.
-
-  Indexes nodes in depth-first order.
-
-  Generally be called via `Meeseeks.Parser.parse`, not directly.
-  """
-  @spec new(TupleTree.t) :: Document.t
-
-  def new(tuple_tree) when is_list(tuple_tree) do
-    add_root_nodes(%Document{}, tuple_tree)
-  end
-
-  def new(tuple_tree) when is_tuple(tuple_tree) do
-    add_root_node(%Document{}, tuple_tree)
-  end
-
-  defp add_root_nodes(document, roots) do
-    Enum.reduce(roots, document, &(add_root_node &2, &1))
-  end
-
-  defp add_root_node(document, {tag, attributes, children}) do
-    id = next_id(document.id_counter)
-    [ns, tg] = split_namespace_from_tag(tag)
-    node = %Element{id: id,
-                    namespace: ns,
-                    tag: tg,
-                    attributes: attributes}
-    %{document |
-      id_counter: id,
-      roots: [id | document.roots],
-      nodes: insert_node(document.nodes, node)}
-    |> add_child_nodes(id, children)
-  end
-
-  defp add_root_node(document, {:comment, comment}) do
-    id = next_id(document.id_counter)
-    node = %Comment{id: id, content: comment}
-    %{document |
-      id_counter: id,
-      roots: [id | document.roots],
-      nodes: insert_node(document.nodes, node)}
-  end
-
-  defp add_root_node(document, {:doctype, type, public, system}) do
-    id = next_id(document.id_counter)
-    node = %Doctype{id: id, type: type, public: public, system: system}
-    %{document |
-      id_counter: id,
-      roots: [id | document.roots],
-      nodes: insert_node(document.nodes, node)}
-  end
-
-  defp add_root_node(document, _other) do
-    document
-  end
-
-  defp add_child_nodes(document, parent_id, children) do
-    Enum.reduce(children, document, &(add_child_node &2, parent_id, &1))
-  end
-
-  defp add_child_node(document, parent, {tag, attributes, children}) do
-    id = next_id(document.id_counter)
-    [ns, tg] = split_namespace_from_tag(tag)
-    node = %Element{parent: parent,
-                    id: id,
-                    namespace: ns,
-                    tag: tg,
-                    attributes: attributes}
-    %{document |
-      id_counter: id,
-      nodes: insert_node(document.nodes, node)}
-    |> add_child_nodes(id, children)
-  end
-
-  defp add_child_node(document, parent, {:comment, comment}) do
-    id = next_id(document.id_counter)
-    node = %Comment{parent: parent, id: id, content: comment}
-    %{document |
-      id_counter: id,
-      nodes: insert_node(document.nodes, node)}
-  end
-
-  defp add_child_node(document, parent, text) when is_binary(text) do
-    id = next_id(document.id_counter)
-    parent_node = get_node(document, parent)
-    if parent_node.tag == "script" or parent_node.tag == "style" do
-      node = %Data{parent: parent, id: id, content: text}
-      %{document |
-        id_counter: id,
-        nodes: insert_node(document.nodes, node)}
-    else
-      node = %Text{parent: parent, id: id, content: text}
-      %{document |
-        id_counter: id,
-        nodes: insert_node(document.nodes, node)}
-    end
-  end
-
-  defp add_child_node(document, _parent, _other) do
-    document
-  end
-
-  defp next_id(nil), do: 1
-  defp next_id(n), do: n + 1
-
-  defp split_namespace_from_tag(maybe_namespaced_tag) do
-    case :binary.split(maybe_namespaced_tag, ":", []) do
-      [tg] -> [nil, tg]
-      [ns, tg] -> [ns, tg]
-    end
-  end
-
-  defp insert_node(nodes, %{parent: nil, id: id} = node) do
-    Map.put(nodes, id, node)
-  end
-
-  defp insert_node(nodes, %{parent: parent, id: child} = node) do
-    parent_node = Map.get(nodes, parent)
-    children = parent_node.children
-    nodes
-    |> Map.put(child, node)
-    |> Map.put(parent, %{parent_node | children: [child | children]})
-  end
 
   # Query
 
@@ -220,8 +92,7 @@ defmodule Meeseeks.Document do
   @spec children(Document.t, node_id) :: [node_id]
   def children(document, node_id) do
     case get_node(document, node_id) do
-      %Document.Element{children: children} ->
-        Enum.reverse(children)
+      %Document.Element{children: children} -> children
       _ -> []
     end
   end
@@ -236,8 +107,7 @@ defmodule Meeseeks.Document do
   @spec descendants(Document.t, node_id) :: [node_id]
   def descendants(document, node_id) do
     case get_node(document, node_id) do
-      %Element{children: cs} ->
-        children = Enum.reverse(cs)
+      %Element{children: children} ->
         Enum.flat_map(children, &[&1 | descendants(document, &1)])
       _ -> []
     end

--- a/lib/meeseeks/document/element.ex
+++ b/lib/meeseeks/document/element.ex
@@ -7,7 +7,7 @@ defmodule Meeseeks.Document.Element do
   alias Meeseeks.Document.Helpers
 
   @enforce_keys [:id]
-  defstruct parent: nil, id: nil, namespace: nil, tag: "", attributes: [], children: []
+  defstruct parent: nil, id: nil, namespace: "", tag: "", attributes: [], children: []
 
   @self_closing_tags ["area", "base", "br", "col", "command", "embed", "hr",
                       "img", "input", "keygen", "link", "meta", "param",

--- a/lib/meeseeks/parser.ex
+++ b/lib/meeseeks/parser.ex
@@ -12,8 +12,8 @@ defmodule Meeseeks.Parser do
   @spec parse(source) :: Document.t | error
 
   def parse(html_string) when is_binary(html_string) do
-    case Html5ever.parse(html_string) do
-      {:ok, tuple_tree} -> parse_tuple_tree(tuple_tree)
+    case MeeseeksHtml5ever.parse(html_string) do
+      {:ok, document} -> document
       {:error, error} -> {:error, error}
     end
   end

--- a/lib/meeseeks/parser.ex
+++ b/lib/meeseeks/parser.ex
@@ -2,20 +2,146 @@ defmodule Meeseeks.Parser do
   @moduledoc false
 
   alias Meeseeks.{Document, TupleTree}
+  alias Meeseeks.Document.{Comment, Data, Doctype, Element, Text}
 
   @type source :: String.t | TupleTree.t
   @type error :: {:error, String.t}
+
+  # Parse
 
   @spec parse(source) :: Document.t | error
 
   def parse(html_string) when is_binary(html_string) do
     case Html5ever.parse(html_string) do
-      {:ok, parsed_html} ->  Document.new(parsed_html)
+      {:ok, tuple_tree} -> parse_tuple_tree(tuple_tree)
       {:error, error} -> {:error, error}
     end
   end
 
   def parse(tuple_tree) do
-    Document.new(tuple_tree)
+    parse_tuple_tree(tuple_tree)
+  end
+
+  # Parse TupleTree
+
+  @spec parse_tuple_tree(TupleTree.t) :: Document.t
+
+  defp parse_tuple_tree(tuple_tree) when is_list(tuple_tree) do
+    add_root_nodes(%Document{}, tuple_tree)
+  end
+
+  defp parse_tuple_tree(tuple_tree) when is_tuple(tuple_tree) do
+    add_root_node(%Document{}, tuple_tree)
+  end
+
+  defp add_root_nodes(document, roots) do
+    Enum.reduce(roots, document, &(add_root_node &2, &1))
+  end
+
+  defp add_root_node(document, {tag, attributes, children}) do
+    id = next_id(document.id_counter)
+    [ns, tg] = split_namespace_from_tag(tag)
+    node = %Element{id: id,
+                    namespace: ns,
+                    tag: tg,
+                    attributes: attributes}
+    %{document |
+      id_counter: id,
+      roots: document.roots ++ [id],
+      nodes: insert_node(document.nodes, node)}
+    |> add_child_nodes(id, children)
+  end
+
+  defp add_root_node(document, {:comment, comment}) do
+    id = next_id(document.id_counter)
+    node = %Comment{id: id, content: comment}
+    %{document |
+      id_counter: id,
+      roots: document.roots ++ [id],
+      nodes: insert_node(document.nodes, node)}
+  end
+
+  defp add_root_node(document, {:doctype, type, public, system}) do
+    id = next_id(document.id_counter)
+    node = %Doctype{id: id, type: type, public: public, system: system}
+    %{document |
+      id_counter: id,
+      roots: document.roots ++ [id],
+      nodes: insert_node(document.nodes, node)}
+  end
+
+  defp add_root_node(document, _other) do
+    document
+  end
+
+  defp add_child_nodes(document, parent_id, children) do
+    Enum.reduce(children, document, &(add_child_node &2, parent_id, &1))
+  end
+
+  defp add_child_node(document, parent, {tag, attributes, children}) do
+    id = next_id(document.id_counter)
+    [ns, tg] = split_namespace_from_tag(tag)
+    node = %Element{parent: parent,
+                    id: id,
+                    namespace: ns,
+                    tag: tg,
+                    attributes: attributes}
+    %{document |
+      id_counter: id,
+      nodes: insert_node(document.nodes, node)}
+    |> add_child_nodes(id, children)
+  end
+
+  defp add_child_node(document, parent, {:comment, comment}) do
+    id = next_id(document.id_counter)
+    node = %Comment{parent: parent, id: id, content: comment}
+    %{document |
+      id_counter: id,
+      nodes: insert_node(document.nodes, node)}
+  end
+
+  defp add_child_node(document, parent, text) when is_binary(text) do
+    id = next_id(document.id_counter)
+    parent_node = Document.get_node(document, parent)
+    if parent_node.tag == "script" or parent_node.tag == "style" do
+      node = %Data{parent: parent, id: id, content: text}
+      %{document |
+        id_counter: id,
+        nodes: insert_node(document.nodes, node)}
+    else
+      node = %Text{parent: parent, id: id, content: text}
+      %{document |
+        id_counter: id,
+        nodes: insert_node(document.nodes, node)}
+    end
+  end
+
+  defp add_child_node(document, _parent, _other) do
+    document
+  end
+
+  defp next_id(nil), do: 1
+  defp next_id(n), do: n + 1
+
+  defp split_namespace_from_tag(maybe_namespaced_tag) do
+    case :binary.split(maybe_namespaced_tag, ":", []) do
+      [tg] -> ["", tg]
+      [ns, tg] -> [ns, tg]
+    end
+  end
+
+  defp insert_node(nodes, %{parent: nil, id: id} = node) do
+    Map.put(nodes, id, node)
+  end
+
+  defp insert_node(nodes, %{parent: parent, id: child} = node) do
+    parent_node = Map.get(nodes, parent)
+    children = parent_node.children
+    nodes
+    |> Map.put(child, node)
+    # List append is a horrible way to build children, but the alternative
+    # is walking all of the nodes at the end and reversing children, which
+    # ends up being more expensive due to the iteration and map update costs.
+    |> Map.put(parent, %{parent_node | children: children ++ [child]})
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -16,11 +16,11 @@ defmodule Meeseeks.Mixfile do
   end
 
   def application do
-    [applications: [:html5ever, :logger, :rustler]]
+    [applications: [:meeseeks_html5ever, :logger, :rustler]]
   end
 
   defp deps do
-    [{:html5ever, "~> 0.3.0"},
+    [{:meeseeks_html5ever, "~> 0.4.1"},
 
      # dev
      {:credo, "~> 0.6.1", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -6,4 +6,5 @@
   "hoedown": {:git, "https://github.com/hoedown/hoedown.git", "980b9c549b4348d50b683ecee6abee470b98acda", []},
   "html5ever": {:hex, :html5ever, "0.3.0", "54fcb8331290363fd0e85301675e6079daf1524aef436104ed0bf485bc0757cd", [:mix], [{:rustler, "~> 0.9", [hex: :rustler, optional: false]}]},
   "markdown": {:git, "https://github.com/devinus/markdown.git", "d065dbcc4e242a85ca2516fdadd0082712871fd8", []},
+  "meeseeks_html5ever": {:hex, :meeseeks_html5ever, "0.4.1", "6361dcf1da4c2575d81f038b516164bbab9c57159d39017c37755d6fa812cfc5", [:mix], [{:rustler, "~> 0.9", [hex: :rustler, optional: false]}]},
   "rustler": {:hex, :rustler, "0.9.0", "6fa87ac78f48f70aa8ecfb6e16b8af41c398989d33de41d292b5581d6a2eeb5a", [:mix], []}}

--- a/test/meeseeks/document_test.exs
+++ b/test/meeseeks/document_test.exs
@@ -3,7 +3,7 @@ defmodule Meeseeks.DocumentTest do
 
   alias Meeseeks.Document
 
-  @document Document.new(
+  @document Meeseeks.Parser.parse(
     {"html", [], [
         {"head", [], []},
         {"body", [], [

--- a/test/meeseeks/parser/tuple_tree_test.exs
+++ b/test/meeseeks/parser/tuple_tree_test.exs
@@ -1,0 +1,22 @@
+defmodule Meeseeks.Parser.TupleTreeTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Parser
+
+  @tuple_tree {"html", [], [
+                  {"head", [], []},
+                  {"body", [], [
+                      {"div", [], [
+                          {"p", [], []},
+                          {"p", [], []},
+                          {"div", [], [
+                              {"p", [], []},
+                              {"p", [], []}]},
+                          {"p", [], []}]}]}]}
+
+  @string "<html><head></head><body><div><p></p><p></p><div><p></p><p></p></div><p></p></div></body></html>"
+
+  test "tuple tree parser makes same document as string parser" do
+    assert Parser.parse(@tuple_tree) == Parser.parse(@string)
+  end
+end


### PR DESCRIPTION
[meeseeks_html5ever](https://github.com/mischov/meeseeks_html5ever) is designed for Meeseeks, and it parses strings of HTML directly into the `Meeseeks.Document` that `Meeseeks.parse` outputs, thereby saving the need to build a document from a tuple-tree that [html5ever_elixir](https://github.com/hansihe/html5ever_elixir) returns.

See #2 for more information.