### PR TITLE
Add XPath selectors (#9)

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -25,7 +25,7 @@
 
         {Credo.Check.Readability.FunctionNames},
         {Credo.Check.Readability.LargeNumbers},
-        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 100},
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 110},
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc},
         {Credo.Check.Readability.ModuleNames},

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -59,11 +59,15 @@ Next, use one of Meeseeks's two selection functions, `all` or `one`, to search f
 
 `all` returns a list of results representing every node matching one of the provided selectors, while `one` returns a result representing the first node to match a selector (depth-first).
 
-Use the `css` macro provided by [`Meeseeks.CSS`](https://hexdocs.pm/meeseeks/Meeseeks.CSS.html) to generate selectors.
+Use the `css` macro provided by [`Meeseeks.CSS`](https://hexdocs.pm/meeseeks/Meeseeks.CSS.html) or the `xpath` macro provided by [`Meeseeks.XPath`](https://hexdocs.pm/meeseeks/Meeseeks.XPath.html) to generate selectors.
 
 ```elixir
 import Meeseeks.CSS
 result = Meeseeks.one(document, css("#main p"))
+#=> #Meeseeks.Result<{ <p>1</p> }>
+
+import Meeseeks.XPath
+result = Meeseeks.one(document, xpath("//*[@id='main']//p"))
 #=> #Meeseeks.Result<{ <p>1</p> }>
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The selection functions accept an unparsed source, but parsing is expensive, so 
 
 ### Select
 
-Next, use one of Meeseeks's two selection functions, `all` or `one`, to search for nodes. Both functions accept a queryable (a source, a document, or a [`Meeseeks.Result`](https://hexdocs.pm/meeseeks/Meeseeks.Result.html)) and one or more [`Meeseeks.Selector`](https://hexdocs.pm/meeseeks/Meeseeks.Selector.html)s.
+Next, use one of Meeseeks's two selection functions, `all` or `one`, to search for nodes. Both functions accept a queryable (a source, a document, or a [`Meeseeks.Result`](https://hexdocs.pm/meeseeks/Meeseeks.Result.html)), one or more [`Meeseeks.Selector`](https://hexdocs.pm/meeseeks/Meeseeks.Selector.html)s, and optionally an initial context.
 
 `all` returns a list of results representing every node matching one of the provided selectors, while `one` returns a result representing the first node to match a selector (depth-first).
 
@@ -94,11 +94,11 @@ defmodule CommentContainsSelector do
 
   defstruct value: ""
 
-  def match?(selector, %Document.Comment{} = node, _document) do
+  def match(selector, %Document.Comment{} = node, _document, _context) do
     String.contains?(node.content, selector.value)
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 end

--- a/lib/meeseeks.ex
+++ b/lib/meeseeks.ex
@@ -1,6 +1,6 @@
 defmodule Meeseeks do
 
-  alias Meeseeks.{Document, Parser, Result, Select, Selector, TupleTree}
+  alias Meeseeks.{Context, Document, Parser, Result, Select, Selector, TupleTree}
 
   @moduledoc """
   Meeseeks is an Elixir library for extracting data from HTML.
@@ -49,8 +49,8 @@ defmodule Meeseeks do
 
   Next, use one of Meeseeks's two selection functions, `all` or `one`, to
   search for nodes. Both functions accept a queryable (a source, a
-  document, or a `Meeseeks.Result`) and one or more
-  `Meeseeks.Selector`s.
+  document, or a `Meeseeks.Result`), one or more `Meeseeks.Selector`s, and
+  optionally an initial context.
 
   `all` returns a list of results representing every node matching one of
   the provided selectors, while `one` returns a result representing the
@@ -94,11 +94,11 @@ defmodule Meeseeks do
 
     defstruct value: ""
 
-    def match?(selector, %Document.Comment{} = node, _document) do
+    def match(selector, %Document.Comment{} = node, _document, _context) do
       String.contains?(node.content, selector.value)
     end
 
-    def match?(_selector, _node, _document) do
+    def match(_selector, _node, _document, _context) do
       false
     end
   end
@@ -140,6 +140,9 @@ defmodule Meeseeks do
   @doc """
   Returns a `Result` for each node in the queryable matching a selector.
 
+  Optionally accepts an initial_context map that will be used to create the
+  context available to selectors.
+
   ## Examples
 
       iex> import Meeseeks.CSS
@@ -147,22 +150,31 @@ defmodule Meeseeks do
       #Meeseeks.Result<{ <p>1</p> }>
   """
   @spec all(queryable, selectors) :: [Result.t]
-  def all(%Document{} = queryable, selectors) do
-    Select.all(queryable, selectors)
+  def all(queryable, selectors) do
+    all(queryable, selectors, %{})
   end
 
-  def all(%Result{} = queryable, selectors) do
-    Select.all(queryable, selectors)
+  @spec all(queryable, selectors, Context.t) :: [Result.t]
+  def all(%Document{} = queryable, selectors, initial_context) do
+    Select.all(queryable, selectors, initial_context)
   end
 
-  def all(source, selectors) do
+  def all(%Result{} = queryable, selectors, initial_context) do
+    Select.all(queryable, selectors, initial_context)
+  end
+
+  def all(source, selectors, initial_context) do
     source
     |> parse()
-    |> Select.all(selectors)
+    |> Select.all(selectors, initial_context)
   end
 
   @doc """
-  Returns a `Result` for the first node in the queryable (depth-first) matching a selector.
+  Returns a `Result` for the first node in the queryable (depth-first)
+  matching a selector.
+
+  Optionally accepts an initial_context map that will be used to create the
+  context available to selectors.
 
   ## Examples
 
@@ -171,18 +183,23 @@ defmodule Meeseeks do
       #Meeseeks.Result<{ <p>1</p> }>
   """
   @spec one(queryable, selectors) :: Result.t
-  def one(%Document{} = queryable, selectors) do
-    Select.one(queryable, selectors)
+  def one(queryable, selectors) do
+    one(queryable, selectors, %{})
   end
 
-  def one(%Result{} = queryable, selectors) do
-    Select.one(queryable, selectors)
+  @spec one(queryable, selectors, Context.t) :: Result.t
+  def one(%Document{} = queryable, selectors, initial_context) do
+    Select.one(queryable, selectors, initial_context)
   end
 
-  def one(source, selectors) do
+  def one(%Result{} = queryable, selectors, initial_context) do
+    Select.one(queryable, selectors, initial_context)
+  end
+
+  def one(source, selectors, initial_context) do
     source
     |> parse()
-    |> Select.one(selectors)
+    |> Select.one(selectors, initial_context)
   end
 
   # Extract

--- a/lib/meeseeks.ex
+++ b/lib/meeseeks.ex
@@ -56,11 +56,16 @@ defmodule Meeseeks do
   the provided selectors, while `one` returns a result representing the
   first node to match a selector (depth-first).
 
-  Use the `css` macro provided by `Meeseeks.CSS` to generate selectors.
+  Use the `css` macro provided by `Meeseeks.CSS` or the `xpath` macro
+  provided by `Meeseeks.XPath` to generate selectors.
 
   ```elixir
   import Meeseeks.CSS
   result = Meeseeks.one(document, css("#main p"))
+  #=> #Meeseeks.Result<{ <p>1</p> }>
+
+  import Meeseeks.XPath
+  result = Meeseeks.one(document, xpath("//*[@id='main']//p"))
   #=> #Meeseeks.Result<{ <p>1</p> }>
   ```
 

--- a/lib/meeseeks/accumulator/all.ex
+++ b/lib/meeseeks/accumulator/all.ex
@@ -1,12 +1,19 @@
 defmodule Meeseeks.Accumulator.All do
   @moduledoc false
 
-  alias Meeseeks.Accumulator.All
-  alias Meeseeks.{Document, Result}
+  use Meeseeks.Accumulator
 
-  defstruct(
-    values: %{}
-  )
+  alias Meeseeks.{Accumulator, Result}
 
-  @type t :: %All{values: %{optional(Document.node_id) => Result.t}}
+  defstruct values: %{}
+
+  def add(%Accumulator.All{values: values} = acc, document, id) do
+    result = %Result{document: document, id: id}
+    %{acc | values: Map.put(values, id, result)}
+  end
+
+  def return(%Accumulator.All{values: values}) do
+    Map.values(values)
+    |> Enum.sort(&(&1.id <= &2.id))
+  end
 end

--- a/lib/meeseeks/accumulator/one.ex
+++ b/lib/meeseeks/accumulator/one.ex
@@ -1,12 +1,19 @@
 defmodule Meeseeks.Accumulator.One do
   @moduledoc false
 
-  alias Meeseeks.Accumulator.One
-  alias Meeseeks.Result
+  use Meeseeks.Accumulator
 
-  defstruct(
-    value: nil
-  )
+  alias Meeseeks.{Accumulator, Result}
 
-  @type t :: %One{value: Result.t | nil}
+  defstruct value: nil
+
+  def add(%Accumulator.One{value: nil} = acc, document, id) do
+    result = %Result{document: document, id: id}
+    %{acc | value: result}
+  end
+
+  def complete?(%Accumulator.One{value: nil}), do: false
+  def complete?(%Accumulator.One{value: _some}), do: true
+
+  def return(%Accumulator.One{value: value}), do: value
 end

--- a/lib/meeseeks/context.ex
+++ b/lib/meeseeks/context.ex
@@ -1,0 +1,118 @@
+defmodule Meeseeks.Context do
+  @moduledoc """
+  Context is available to both Meeseek's selection process and each
+  individual selector, and allows for selectors to build state (or receive
+  state from the selection mechanism).
+
+  The selection process expects an `accumulator`, `return?` boolean, and
+  `matches` map to exist in the context, and stores selected nodes in the
+  `accumulator`, stores matching nodes than need to be filtered in the
+  `matches` map, and halts selection if the `return?` boolean becomes true.
+  """
+
+  alias Meeseeks.{Accumulator, Document, Selector}
+
+  @accumulator :"__accumulator__"
+  @return? :"__return?__"
+  @matches :"__matches__"
+  @nodes :"__nodes__"
+
+  @type t :: %{optional(any) => any}
+
+  @doc """
+  Creates a new context from an initial_context map.
+  """
+  @spec new(t) :: t
+  def new(initial_context) do
+    initial_context
+    |> Map.put(@return?, false)
+    |> Map.put(@matches, %{})
+  end
+
+  @doc """
+  Adds an accumulator to context, overriding any accumulator provided in the
+  initial context.
+  """
+  @spec with_accumulator(t, Accumulator.t) :: t
+  def with_accumulator(context, acc) do
+    Map.put(context, @accumulator, acc)
+  end
+
+  @doc """
+  Updates the context's accumulator with the result of calling
+  Accumulator.add on the current accumulator with the provided document and
+  id, and sets return? to the result of calling Accumulator.complete? on the
+  updated accumulator if return? was not already true.
+  """
+  @spec add_to_accumulator(t, Document.t, Document.node_id) :: t
+  def add_to_accumulator(%{@accumulator => acc, @return? => ret} = context, document, id) do
+    acc = Accumulator.add(acc, document, id)
+    ret = ret or Accumulator.complete?(acc)
+    %{context |
+      @accumulator => acc,
+      @return? => ret}
+  end
+
+  @doc """
+  Returns the result of calling Accumulator.return on the context's
+  accumulator.
+  """
+  @spec return_accumulator(t) :: any
+  def return_accumulator(%{@accumulator => acc}) do
+    Accumulator.return(acc)
+  end
+
+  @doc """
+  Adds a node to a list in the context's matches map corresponding to the
+  selector that the node matched.
+  """
+  @spec add_to_matches(t, Selector.t, Document.node_t) :: t
+  def add_to_matches(%{@matches => matches} = context, selector, node) do
+    case Map.fetch(matches, selector) do
+      {:ok, nodes} -> put_in(context[@matches][selector], [node|nodes])
+      :error -> put_in(context[@matches][selector], [node])
+    end
+  end
+
+  @doc """
+  Clears the context's matches map.
+  """
+  @spec clear_matches(t) :: t
+  def clear_matches(context) do
+    Map.put(context, @matches, %{})
+  end
+
+  @doc """
+  Returns the key under which the accumulator is stored in the context.
+  """
+  @spec accumulator_key() :: atom
+  def accumulator_key() do
+    @accumulator
+  end
+
+  @doc """
+  Returns the key under which return? is stored in the context.
+  """
+  @spec return_key() :: atom
+  def return_key() do
+    @return?
+  end
+
+  @doc """
+  Returns the key under which matching nodes that need to be filtered are
+  stored in the context.
+  """
+  @spec matches_key() :: atom
+  def matches_key() do
+    @matches
+  end
+
+  @doc """
+  Returns the key under which the nodes currently being walked are stored in
+  the context.
+  """
+  @spec nodes_key() :: atom
+  def nodes_key() do
+    @nodes
+  end
+end

--- a/lib/meeseeks/document.ex
+++ b/lib/meeseeks/document.ex
@@ -83,6 +83,31 @@ defmodule Meeseeks.Document do
   end
 
   @doc """
+  Returns the node id of node_id's parent in the context of the document, or
+  nil if node_id does not have a parent.
+  """
+  @spec parent(Document.t, node_id) :: node_id | nil
+  def parent(document, node_id) do
+    case get_node(document, node_id) do
+      %{parent: nil} -> nil
+      %{parent: parent} -> parent
+    end
+  end
+
+  @doc """
+  Returns the node ids of node_id's ancestors in the context of the document.
+
+  Returns the ancestors in reverse order: `[parent, grandparent, ...]`
+  """
+  @spec ancestors(Document.t, node_id) :: [node_id]
+  def ancestors(document, node_id) do
+    case parent(document, node_id) do
+      nil -> []
+      parent_id -> [parent_id | ancestors(document, parent_id)]
+    end
+  end
+
+  @doc """
   Returns the node ids of node_id's children in the context of the document.
 
   Returns *all* children, not just those that are `Meeseeks.Document.Element`s.
@@ -132,10 +157,26 @@ defmodule Meeseeks.Document do
   end
 
   @doc """
+  Returns the node ids of the siblings that come before node_id in the
+  context of the document.
+
+  Returns *all* of these siblings, not just those that are `Meeseeks.Document.Element`s.
+
+  Returns siblings in depth-first order.
+  """
+  @spec previous_siblings(Document.t, node_id) :: [node_id]
+  def previous_siblings(document, node_id) do
+    document
+    |> siblings(node_id)
+    |> Enum.take_while(fn(id) -> id != node_id end)
+  end
+
+  @doc """
   Returns the node ids of the siblings that come after node_id in the context
   of the document.
 
-  Returns *all* of these siblings, not just those that are `Meeseeks.Document.Element`s
+  Returns *all* of these siblings, not just those that are
+  `Meeseeks.Document.Element`s.
 
   Returns siblings in depth-first order.
   """

--- a/lib/meeseeks/select.ex
+++ b/lib/meeseeks/select.ex
@@ -1,134 +1,223 @@
 defmodule Meeseeks.Select do
   @moduledoc false
 
-  alias Meeseeks.{Accumulator, Document, Result, Selector}
+  alias Meeseeks.{Accumulator, Context, Document, Result, Selector}
+
+  @return? Context.return_key()
+  @matches Context.matches_key()
+  @nodes Context.nodes_key()
 
   @type queryable :: Document.t | Result.t
   @type selectors :: Selector.t | [Selector.t]
 
   # All
 
-  @spec all(queryable, selectors) :: [Result.t]
-  def all(queryable, selectors)
+  @spec all(queryable, selectors, Context.t) :: [Result.t]
+  def all(queryable, selectors, initial_context)
 
-  def all(_queryable, string) when is_binary(string) do
+  def all(_queryable, string, _initial_context) when is_binary(string) do
     raise "Received string when expecting selectors; did you mean to wrap \"#{string}\" in the css macro?"
   end
 
-  def all(queryable, selectors) do
-    walk(queryable, selectors, %Accumulator.All{})
+  def all(queryable, selectors, initial_context) do
+    context = Context.new(initial_context)
+    |> Context.with_accumulator(%Accumulator.All{})
+    walk(queryable, selectors, context)
   end
 
   # One
 
-  @spec one(queryable, selectors) :: Result.t
-  def one(queryable, selectors)
+  @spec one(queryable, selectors, Context.t) :: Result.t
+  def one(queryable, selectors, initial_context)
 
-  def one(_queryable, string) when is_binary(string) do
+  def one(_queryable, string, _initial_context) when is_binary(string) do
     raise "Received string when expecting selectors; did you mean to wrap \"#{string}\" in the css macro?"
   end
 
-  def one(queryable, selectors) do
-    walk(queryable, selectors, %Accumulator.One{})
+  def one(queryable, selectors, initial_context) do
+    context = Context.new(initial_context)
+    |> Context.with_accumulator(%Accumulator.One{})
+    walk(queryable, selectors, context)
   end
 
   # Walk
 
-  defp walk(%Document{} = document, selectors, acc) do
+  defp walk(%Document{} = document, selectors, context) do
     document
     |> Document.get_nodes()
-    |> walk_nodes(document, selectors, acc)
-    |> Accumulator.return
+    |> walk_nodes(document, selectors, context)
+    |> Context.return_accumulator()
   end
 
-  defp walk(%Result{id: id, document: document}, selectors, acc) do
+  defp walk(%Result{id: id, document: document}, selectors, context) do
     ids = [id | Document.descendants(document, id)]
     document
     |> Document.get_nodes(ids)
-    |> walk_nodes(document, selectors, acc)
-    |> Accumulator.return
+    |> walk_nodes(document, selectors, context)
+    |> Context.return_accumulator()
   end
 
   # Walk Nodes
 
-  defp walk_nodes(_, _, _, %Accumulator.One{value: v} = acc) when v != nil do
-    acc
+  defp walk_nodes(_, _, _, %{@return? => true} = context) do
+    context
   end
 
-  defp walk_nodes([], _, _, acc) do
-    acc
+  defp walk_nodes([], document, _, %{@matches => matches} = context) when map_size(matches) > 0 do
+    filter_and_walk(matches, document, context)
   end
 
-  defp walk_nodes(_, _, [], acc) do
-    acc
+  defp walk_nodes([], _, _, context) do
+    context
   end
 
-  defp walk_nodes(nodes, document, selectors, acc) do
-    Enum.reduce(
+  defp walk_nodes(_, document, [], %{@matches => matches} = context) when map_size(matches) > 0 do
+    filter_and_walk(matches, document, context)
+  end
+
+  defp walk_nodes(_, _, [], context) do
+    context
+  end
+
+  defp walk_nodes(nodes, document, selectors, context) do
+    context = Enum.reduce(
       nodes,
-      acc,
-      fn(nd, acc) -> walk_node(nd, document, selectors, acc) end
-    )
+      Context.clear_matches(context),
+      fn(node, context) -> walk_node(node, document, selectors, context) end)
+    walk_nodes([], document, [], context)
   end
 
   # Walk Node
 
-  defp walk_node(_, _, _, %Accumulator.One{value: v} = acc) when v != nil do
-    acc
+  defp walk_node(_, _, _, %{@return? => true} = context) do
+    context
   end
 
-  defp walk_node(nil, _, _, acc) do
-    acc
+  defp walk_node(nil, _, _, context) do
+    context
   end
 
-  defp walk_node(_, _, [], acc) do
-    acc
+  defp walk_node(_, _, [], context) do
+    context
   end
 
-  defp walk_node(node, document, [selector|selectors], acc) do
-    acc = walk_node(node, document, selector, acc)
-    walk_node(node, document, selectors, acc)
+  defp walk_node(node, document, [selector|selectors], context) do
+    context = walk_node(node, document, selector, context)
+    walk_node(node, document, selectors, context)
   end
 
-  defp walk_node(%Document.Element{} = node, document, %Selector.Element{} = selector, acc) do
-    if Selector.match?(selector, node, document) do
-      case Selector.combinator(selector) do
-        nil -> Accumulator.add(acc, document, node.id)
-        combinator -> walk_combinator(combinator, node, document, acc)
-      end
-    else
-      acc
+  defp walk_node(%Document.Element{} = node, document, %Selector.Element{} = selector, context) do
+    case Selector.match(selector, node, document, context) do
+      false -> context
+      {false, context} -> context
+      true -> handle_match(node, document, selector, context)
+      {true, context} -> handle_match(node, document, selector, context)
     end
   end
 
-  defp walk_node(_node, _document, %Selector.Element{} = _selector, acc) do
-    acc
+  defp walk_node(_node, _document, %Selector.Element{} = _selector, context) do
+    context
   end
 
-  defp walk_node(node, document, selector, acc) do
-    if Selector.match?(selector, node, document) do
-      case Selector.combinator(selector) do
-        nil -> Accumulator.add(acc, document, node.id)
-        combinator -> walk_combinator(combinator, node, document, acc)
-      end
-    else
-      acc
+  defp walk_node(node, document, selector, context) do
+    case Selector.match(selector, node, document, context) do
+      false -> context
+      {false, context} -> context
+      true -> handle_match(node, document, selector, context)
+      {true, context} -> handle_match(node, document, selector, context)
     end
+  end
+
+  # Handle Match
+
+  defp handle_match(node, document, selector, context) do
+    case Selector.filters(selector) do
+      # No filters, accumulate or walk directly
+      nil ->
+        case Selector.combinator(selector) do
+          nil -> Context.add_to_accumulator(context, document, node.id)
+          combinator -> walk_combinator(combinator, node, document, context)
+        end
+      # Filters, accumulate or store for filtering
+      filters ->
+        combinator = Selector.combinator(selector)
+        case {combinator, filters} do
+          # Add to accumulator if there is no combinator and no filters
+          {nil, []} -> Context.add_to_accumulator(context, document, node.id)
+          # Add to @matches so all matching nodes can be filtered prior to
+          # continuing
+          _ -> Context.add_to_matches(context, selector, node)
+        end
+    end
+  end
+
+  # Filter and Walk
+
+  defp filter_and_walk(matching, document, context) do
+    # For each set of nodes matching a selector
+    Enum.reduce(matching, context, fn({selector, nodes}, context) ->
+      filters = Selector.filters(selector)
+      nodes = Enum.reverse(nodes)
+      # Filter the nodes based on the selector's filters
+      {nodes, context} = filter_nodes(filters, nodes, document, context)
+      walk_filtered(nodes, document, selector, context)
+    end)
+  end
+
+  defp walk_filtered(nodes, document, selector, context) do
+    # For each remaining node either
+    Enum.reduce(nodes, context, fn(node, context) ->
+      case Selector.combinator(selector) do
+        # Add the node to the accumulator if there is no combinator
+        nil ->
+          Context.add_to_accumulator(context, document, node.id)
+        # Or walk the combinator
+        combinator ->
+          walk_combinator(combinator, node, document, context)
+      end
+    end)
+  end
+
+  defp filter_nodes([], nodes, _, context) do
+    {nodes, context}
+  end
+
+  defp filter_nodes(filters, nodes, document, context) when is_list(filters) do
+    context = Map.put(context, @nodes, nodes)
+    Enum.reduce(filters, {nodes, context}, fn(filter, {nodes, context}) ->
+      filter_nodes(filter, nodes, document, context)
+      |> reverse_filtered_nodes()
+    end)
+  end
+
+  defp filter_nodes(filter, nodes, document, context) do
+    Enum.reduce(nodes, {[], context}, fn(node, {nodes, context}) ->
+      case Selector.match(filter, node, document, context) do
+        false -> {nodes, context}
+        {false, context} -> {nodes, context}
+        true -> {[node|nodes], context}
+        {true, context} -> {[node|nodes], context}
+      end
+    end)
+  end
+
+  defp reverse_filtered_nodes({nodes, context}) do
+    {Enum.reverse(nodes), context}
   end
 
   # Walk Combinator
 
-  defp walk_combinator(combinator, node, document, acc) do
+  defp walk_combinator(combinator, node, document, context) do
     case Selector.Combinator.next(combinator, node, document) do
-      nil -> acc
+      nil -> context
 
       nodes when is_list(nodes) ->
         selector = Selector.Combinator.selector(combinator)
-        walk_nodes(nodes, document, selector, acc)
+        walk_nodes(nodes, document, selector, context)
 
       node ->
         selector = Selector.Combinator.selector(combinator)
-        walk_node(node, document, selector, acc)
+        walk_nodes([node], document, selector, context)
     end
   end
 end

--- a/lib/meeseeks/selector/combinator/ancestors.ex
+++ b/lib/meeseeks/selector/combinator/ancestors.ex
@@ -1,0 +1,16 @@
+defmodule Meeseeks.Selector.Combinator.Ancestors do
+  @moduledoc false
+
+  use Meeseeks.Selector.Combinator
+
+  alias Meeseeks.Document
+
+  defstruct selector: nil
+
+  def next(_combinator, node, document) do
+    case Document.ancestors(document, node.id) do
+      [] -> nil
+      ancestors -> Document.get_nodes(document, ancestors)
+    end
+  end
+end

--- a/lib/meeseeks/selector/combinator/ancestors_or_self.ex
+++ b/lib/meeseeks/selector/combinator/ancestors_or_self.ex
@@ -1,0 +1,16 @@
+defmodule Meeseeks.Selector.Combinator.AncestorsOrSelf do
+  @moduledoc false
+
+  use Meeseeks.Selector.Combinator
+
+  alias Meeseeks.Document
+
+  defstruct selector: nil
+
+  def next(_combinator, node, document) do
+    case Document.ancestors(document, node.id) do
+      [] -> node
+      ancestors -> [node | Document.get_nodes(document, ancestors)]
+    end
+  end
+end

--- a/lib/meeseeks/selector/combinator/children.ex
+++ b/lib/meeseeks/selector/combinator/children.ex
@@ -1,0 +1,24 @@
+defmodule Meeseeks.Selector.Combinator.Children do
+  @moduledoc false
+
+  use Meeseeks.Selector.Combinator
+
+  alias Meeseeks.Document
+
+  defstruct selector: nil
+
+  def next(_combinator, %Document.Element{children: []}, _document) do
+    nil
+  end
+
+  def next(_combinator, %Document.Element{} = element, document) do
+    case Document.children(document, element.id) do
+      [] -> nil
+      children -> Document.get_nodes(document, children)
+    end
+  end
+
+  def next(_combinator, _element, _document) do
+    nil
+  end
+end

--- a/lib/meeseeks/selector/combinator/descendants.ex
+++ b/lib/meeseeks/selector/combinator/descendants.ex
@@ -1,0 +1,24 @@
+defmodule Meeseeks.Selector.Combinator.Descendants do
+  @moduledoc false
+
+  use Meeseeks.Selector.Combinator
+
+  alias Meeseeks.Document
+
+  defstruct selector: nil
+
+  def next(_combinator, %Document.Element{children: []}, _document) do
+    nil
+  end
+
+  def next(_combinator, %Document.Element{} = element, document) do
+    case Document.descendants(document, element.id) do
+      [] -> nil
+      descendants -> Document.get_nodes(document, descendants)
+    end
+  end
+
+  def next(_combinator, _element, _document) do
+    nil
+  end
+end

--- a/lib/meeseeks/selector/combinator/descendants_or_self.ex
+++ b/lib/meeseeks/selector/combinator/descendants_or_self.ex
@@ -1,0 +1,24 @@
+defmodule Meeseeks.Selector.Combinator.DescendantsOrSelf do
+  @moduledoc false
+
+  use Meeseeks.Selector.Combinator
+
+  alias Meeseeks.Document
+
+  defstruct selector: nil
+
+  def next(_combinator, %Document.Element{children: []} = element, _document) do
+    element
+  end
+
+  def next(_combinator, %Document.Element{} = element, document) do
+    case Document.descendants(document, element.id) do
+      [] -> [element]
+      descendants -> [element | Document.get_nodes(document, descendants)]
+    end
+  end
+
+  def next(_combinator, node, _document) do
+    node
+  end
+end

--- a/lib/meeseeks/selector/combinator/next_siblings.ex
+++ b/lib/meeseeks/selector/combinator/next_siblings.ex
@@ -1,0 +1,20 @@
+defmodule Meeseeks.Selector.Combinator.NextSiblings do
+  @moduledoc false
+
+  use Meeseeks.Selector.Combinator
+
+  alias Meeseeks.Document
+
+  defstruct selector: nil
+
+  def next(_combinator, %{parent: nil}, _document) do
+    nil
+  end
+
+  def next(_combinator, node, document) do
+    case Document.next_siblings(document, node.id) do
+      [] -> nil
+      next_siblings -> Document.get_nodes(document, next_siblings)
+    end
+  end
+end

--- a/lib/meeseeks/selector/combinator/parent.ex
+++ b/lib/meeseeks/selector/combinator/parent.ex
@@ -1,0 +1,16 @@
+defmodule Meeseeks.Selector.Combinator.Parent do
+  @moduledoc false
+
+  use Meeseeks.Selector.Combinator
+
+  alias Meeseeks.Document
+
+  defstruct selector: nil
+
+  def next(_combinator, node, document) do
+    case Document.parent(document, node.id) do
+      nil -> nil
+      parent -> Document.get_node(document, parent)
+    end
+  end
+end

--- a/lib/meeseeks/selector/combinator/previous_siblings.ex
+++ b/lib/meeseeks/selector/combinator/previous_siblings.ex
@@ -1,0 +1,20 @@
+defmodule Meeseeks.Selector.Combinator.PreviousSiblings do
+  @moduledoc false
+
+  use Meeseeks.Selector.Combinator
+
+  alias Meeseeks.Document
+
+  defstruct selector: nil
+
+  def next(_combinator, %{parent: nil}, _document) do
+    nil
+  end
+
+  def next(_combinator, node, document) do
+    case Document.previous_siblings(document, node.id) do
+      [] -> nil
+      previous_siblings -> Document.get_nodes(document, previous_siblings)
+    end
+  end
+end

--- a/lib/meeseeks/selector/combinator/self.ex
+++ b/lib/meeseeks/selector/combinator/self.ex
@@ -1,0 +1,11 @@
+defmodule Meeseeks.Selector.Combinator.Self do
+  @moduledoc false
+
+  use Meeseeks.Selector.Combinator
+
+  defstruct selector: nil
+
+  def next(_combinator, node, _document) do
+    node
+  end
+end

--- a/lib/meeseeks/selector/element.ex
+++ b/lib/meeseeks/selector/element.ex
@@ -4,16 +4,23 @@ defmodule Meeseeks.Selector.Element do
   use Meeseeks.Selector
 
   alias Meeseeks.{Document, Selector}
+  alias Meeseeks.Selector.Element
 
-  defstruct selectors: [], combinator: nil
+  defstruct selectors: [], combinator: nil, filters: nil
 
-  def match?(selector, %Document.Element{} = element, document) do
-    Enum.all?(selector.selectors, &(Selector.match? &1, element, document))
+  def match(%Element{selectors: []}, %Document.Element{}, _document, _context) do
+    true
   end
 
-  def match?(_selector, _node, _document) do
+  def match(selector, %Document.Element{} = element, document, context) do
+    Enum.all?(selector.selectors, &(Selector.match &1, element, document, context))
+  end
+
+  def match(_selector, _node, _document, _context) do
     false
   end
 
   def combinator(selector), do: selector.combinator
+
+  def filters(selector), do: selector.filters
 end

--- a/lib/meeseeks/selector/element/attribute/attribute.ex
+++ b/lib/meeseeks/selector/element/attribute/attribute.ex
@@ -7,13 +7,13 @@ defmodule Meeseeks.Selector.Element.Attribute.Attribute do
 
   defstruct attribute: nil
 
-  def match?(selector, %Document.Element{} = element, _document) do
+  def match(selector, %Document.Element{} = element, _document, _context) do
     Enum.any?(element.attributes, fn({attribute, _}) ->
       attribute == selector.attribute
     end)
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 end

--- a/lib/meeseeks/selector/element/attribute/attribute_prefix.ex
+++ b/lib/meeseeks/selector/element/attribute/attribute_prefix.ex
@@ -7,13 +7,13 @@ defmodule Meeseeks.Selector.Element.Attribute.AttributePrefix do
 
   defstruct attribute: nil
 
-  def match?(selector, %Document.Element{} = element, _document) do
+  def match(selector, %Document.Element{} = element, _document, _context) do
     Enum.any?(element.attributes, fn({attribute, _}) ->
       String.starts_with?(attribute, selector.attribute)
     end)
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 end

--- a/lib/meeseeks/selector/element/attribute/value.ex
+++ b/lib/meeseeks/selector/element/attribute/value.ex
@@ -8,12 +8,12 @@ defmodule Meeseeks.Selector.Element.Attribute.Value do
 
   defstruct attribute: nil, value: nil
 
-  def match?(selector, %Document.Element{} = element, _document) do
+  def match(selector, %Document.Element{} = element, _document, _context) do
     value = Helpers.get(element.attributes, selector.attribute)
     value == selector.value
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 end

--- a/lib/meeseeks/selector/element/attribute/value_contains.ex
+++ b/lib/meeseeks/selector/element/attribute/value_contains.ex
@@ -8,12 +8,12 @@ defmodule Meeseeks.Selector.Element.Attribute.ValueContains do
 
   defstruct attribute: nil, value: nil
 
-  def match?(selector, %Document.Element{} = element, _document) do
+  def match(selector, %Document.Element{} = element, _document, _context) do
     value = Helpers.get(element.attributes, selector.attribute)
     String.contains?(value, selector.value)
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 end

--- a/lib/meeseeks/selector/element/attribute/value_dash.ex
+++ b/lib/meeseeks/selector/element/attribute/value_dash.ex
@@ -8,12 +8,12 @@ defmodule Meeseeks.Selector.Element.Attribute.ValueDash do
 
   defstruct attribute: nil, value: nil
 
-  def match?(selector, %Document.Element{} = element, _document) do
+  def match(selector, %Document.Element{} = element, _document, _context) do
     value = Helpers.get(element.attributes, selector.attribute)
     value == selector.value || String.starts_with?(value, selector.value <> "-")
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 end

--- a/lib/meeseeks/selector/element/attribute/value_includes.ex
+++ b/lib/meeseeks/selector/element/attribute/value_includes.ex
@@ -8,12 +8,12 @@ defmodule Meeseeks.Selector.Element.Attribute.ValueIncludes do
 
   defstruct attribute: nil, value: nil
 
-  def match?(selector, %Document.Element{} = element, _document) do
+  def match(selector, %Document.Element{} = element, _document, _context) do
     values = Helpers.get(element.attributes, selector.attribute) |> String.split(~r/[ ]+/)
     Enum.any?(values, &(&1 == selector.value))
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 end

--- a/lib/meeseeks/selector/element/attribute/value_prefix.ex
+++ b/lib/meeseeks/selector/element/attribute/value_prefix.ex
@@ -8,12 +8,12 @@ defmodule Meeseeks.Selector.Element.Attribute.ValuePrefix do
 
   defstruct attribute: nil, value: nil
 
-  def match?(selector, %Document.Element{} = element, _document) do
+  def match(selector, %Document.Element{} = element, _document, _context) do
     value = Helpers.get(element.attributes, selector.attribute)
     String.starts_with?(value, selector.value)
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 end

--- a/lib/meeseeks/selector/element/attribute/value_suffix.ex
+++ b/lib/meeseeks/selector/element/attribute/value_suffix.ex
@@ -8,12 +8,12 @@ defmodule Meeseeks.Selector.Element.Attribute.ValueSuffix do
 
   defstruct attribute: nil, value: nil
 
-  def match?(selector, %Document.Element{} = element, _document) do
+  def match(selector, %Document.Element{} = element, _document, _context) do
     value = Helpers.get(element.attributes, selector.attribute)
     String.ends_with?(value, selector.value)
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 end

--- a/lib/meeseeks/selector/element/namespace.ex
+++ b/lib/meeseeks/selector/element/namespace.ex
@@ -8,15 +8,15 @@ defmodule Meeseeks.Selector.Element.Namespace do
 
   defstruct value: nil
 
-  def match?(%Element.Namespace{value: "*"}, %Document.Element{}, _document) do
+  def match(%Element.Namespace{value: "*"}, %Document.Element{}, _document, _context) do
     true
   end
 
-  def match?(selector, %Document.Element{} = element, _document) do
+  def match(selector, %Document.Element{} = element, _document, _context) do
     element.namespace == selector.value
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 end

--- a/lib/meeseeks/selector/element/pseudo_class/first_child.ex
+++ b/lib/meeseeks/selector/element/pseudo_class/first_child.ex
@@ -8,16 +8,16 @@ defmodule Meeseeks.Selector.Element.PseudoClass.FirstChild do
 
   defstruct args: []
 
-  def match?(_selector, %Document.Element{parent: nil}, _document) do
+  def match(_selector, %Document.Element{parent: nil}, _document, _context) do
     false
   end
 
-  def match?(_selector, %Document.Element{} = element, document) do
+  def match(_selector, %Document.Element{} = element, document, _context) do
     first_sibling = Helpers.siblings(element, document) |> List.first()
     element.id == first_sibling
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 

--- a/lib/meeseeks/selector/element/pseudo_class/first_of_type.ex
+++ b/lib/meeseeks/selector/element/pseudo_class/first_of_type.ex
@@ -8,16 +8,16 @@ defmodule Meeseeks.Selector.Element.PseudoClass.FirstOfType do
 
   defstruct args: []
 
-  def match?(_selector, %Document.Element{parent: nil}, _document) do
+  def match(_selector, %Document.Element{parent: nil}, _document, _context) do
     false
   end
 
-  def match?(_selector, %Document.Element{} = element, document) do
+  def match(_selector, %Document.Element{} = element, document, _context) do
     first_of_type = Helpers.siblings_of_type(element, document) |> List.first()
     element.id == first_of_type
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 

--- a/lib/meeseeks/selector/element/pseudo_class/last_child.ex
+++ b/lib/meeseeks/selector/element/pseudo_class/last_child.ex
@@ -8,16 +8,16 @@ defmodule Meeseeks.Selector.Element.PseudoClass.LastChild do
 
   defstruct args: []
 
-  def match?(_selector, %Document.Element{parent: nil}, _document) do
+  def match(_selector, %Document.Element{parent: nil}, _document, _context) do
     false
   end
 
-  def match?(_selector, %Document.Element{} = element, document) do
+  def match(_selector, %Document.Element{} = element, document, _context) do
     last_sibling = Helpers.siblings(element, document) |> List.last()
     element.id == last_sibling
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 

--- a/lib/meeseeks/selector/element/pseudo_class/last_of_type.ex
+++ b/lib/meeseeks/selector/element/pseudo_class/last_of_type.ex
@@ -8,16 +8,16 @@ defmodule Meeseeks.Selector.Element.PseudoClass.LastOfType do
 
   defstruct args: []
 
-  def match?(_selector, %Document.Element{parent: nil}, _document) do
+  def match(_selector, %Document.Element{parent: nil}, _document, _context) do
     false
   end
 
-  def match?(_selector, %Document.Element{} = element, document) do
+  def match(_selector, %Document.Element{} = element, document, _context) do
     last_of_type = Helpers.siblings_of_type(element, document) |> List.last()
     element.id == last_of_type
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 

--- a/lib/meeseeks/selector/element/pseudo_class/not.ex
+++ b/lib/meeseeks/selector/element/pseudo_class/not.ex
@@ -8,18 +8,18 @@ defmodule Meeseeks.Selector.Element.PseudoClass.Not do
 
   defstruct args: []
 
-  def match?(selector, %Document.Element{} = element, document) do
+  def match(selector, %Document.Element{} = element, document, context) do
     case selector.args do
-      [[sel]] -> !Selector.match?(sel, element, document)
+      [[sel]] -> !Selector.match(sel, element, document, context)
 
       [selectors] when is_list(selectors) ->
-        !Enum.any?(selectors, &Selector.match?(&1, element, document))
+        !Enum.any?(selectors, &Selector.match(&1, element, document, context))
 
       _ -> false
     end
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 

--- a/lib/meeseeks/selector/element/pseudo_class/nth_child.ex
+++ b/lib/meeseeks/selector/element/pseudo_class/nth_child.ex
@@ -8,11 +8,11 @@ defmodule Meeseeks.Selector.Element.PseudoClass.NthChild do
 
   defstruct args: []
 
-  def match?(_selector, %Document.Element{parent: nil}, _document) do
+  def match(_selector, %Document.Element{parent: nil}, _document, _context) do
     false
   end
 
-  def match?(selector, %Document.Element{} = element, document) do
+  def match(selector, %Document.Element{} = element, document, _context) do
     case selector.args do
       ["even"] ->
         index = Helpers.index(element, document)
@@ -34,7 +34,7 @@ defmodule Meeseeks.Selector.Element.PseudoClass.NthChild do
     end
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 

--- a/lib/meeseeks/selector/element/pseudo_class/nth_last_child.ex
+++ b/lib/meeseeks/selector/element/pseudo_class/nth_last_child.ex
@@ -8,11 +8,11 @@ defmodule Meeseeks.Selector.Element.PseudoClass.NthLastChild do
 
   defstruct args: []
 
-  def match?(_selector, %Document.Element{parent: nil}, _document) do
+  def match(_selector, %Document.Element{parent: nil}, _document, _context) do
     false
   end
 
-  def match?(selector, %Document.Element{} = element, document) do
+  def match(selector, %Document.Element{} = element, document, _context) do
     case selector.args do
       ["even"] ->
         index = Helpers.backwards_index(element, document)
@@ -34,7 +34,7 @@ defmodule Meeseeks.Selector.Element.PseudoClass.NthLastChild do
     end
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 

--- a/lib/meeseeks/selector/element/pseudo_class/nth_last_of_type.ex
+++ b/lib/meeseeks/selector/element/pseudo_class/nth_last_of_type.ex
@@ -8,11 +8,11 @@ defmodule Meeseeks.Selector.Element.PseudoClass.NthLastOfType do
 
   defstruct args: []
 
-  def match?(_selector, %Document.Element{parent: nil}, _document) do
+  def match(_selector, %Document.Element{parent: nil}, _document, _context) do
     false
   end
 
-  def match?(selector, %Document.Element{} = element, document) do
+  def match(selector, %Document.Element{} = element, document, _context) do
     case selector.args do
       ["even"] ->
         index = Helpers.backwards_index_of_type(element, document)
@@ -34,7 +34,7 @@ defmodule Meeseeks.Selector.Element.PseudoClass.NthLastOfType do
     end
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 

--- a/lib/meeseeks/selector/element/pseudo_class/nth_of_type.ex
+++ b/lib/meeseeks/selector/element/pseudo_class/nth_of_type.ex
@@ -8,11 +8,11 @@ defmodule Meeseeks.Selector.Element.PseudoClass.NthOfType do
 
   defstruct args: []
 
-  def match?(_selector, %Document.Element{parent: nil}, _document) do
+  def match(_selector, %Document.Element{parent: nil}, _document, _context) do
     false
   end
 
-  def match?(selector, %Document.Element{} = element, document) do
+  def match(selector, %Document.Element{} = element, document, _context) do
     case selector.args do
       ["even"] ->
         index = Helpers.index_of_type(element, document)
@@ -34,7 +34,7 @@ defmodule Meeseeks.Selector.Element.PseudoClass.NthOfType do
     end
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 

--- a/lib/meeseeks/selector/element/tag.ex
+++ b/lib/meeseeks/selector/element/tag.ex
@@ -8,15 +8,15 @@ defmodule Meeseeks.Selector.Element.Tag do
 
   defstruct value: nil
 
-  def match?(%Element.Tag{value: "*"}, %Document.Element{}, _document) do
+  def match(%Element.Tag{value: "*"}, %Document.Element{}, _document, _context) do
     true
   end
 
-  def match?(selector, %Document.Element{} = element, _document) do
+  def match(selector, %Document.Element{} = element, _document, _context) do
     element.tag == selector.value
   end
 
-  def match?(_selector, _node, _document) do
+  def match(_selector, _node, _document, _context) do
     false
   end
 end

--- a/lib/meeseeks/selector/node.ex
+++ b/lib/meeseeks/selector/node.ex
@@ -4,12 +4,19 @@ defmodule Meeseeks.Selector.Node do
   use Meeseeks.Selector
 
   alias Meeseeks.Selector
+  alias Meeseeks.Selector.Node
 
-  defstruct selectors: [], combinator: nil
+  defstruct selectors: [], combinator: nil, filters: nil
 
-  def match?(selector, node, document) do
-    Enum.all?(selector.selectors, &(Selector.match? &1, node, document))
+  def match(%Node{selectors: []}, _node, _document, _context) do
+    true
+  end
+
+  def match(selector, node, document, context) do
+    Enum.all?(selector.selectors, &(Selector.match &1, node, document, context))
   end
 
   def combinator(selector), do: selector.combinator
+
+  def filters(selector), do: selector.filters
 end

--- a/lib/meeseeks/selector/node.ex
+++ b/lib/meeseeks/selector/node.ex
@@ -1,0 +1,15 @@
+defmodule Meeseeks.Selector.Node do
+  @moduledoc false
+
+  use Meeseeks.Selector
+
+  alias Meeseeks.Selector
+
+  defstruct selectors: [], combinator: nil
+
+  def match?(selector, node, document) do
+    Enum.all?(selector.selectors, &(Selector.match? &1, node, document))
+  end
+
+  def combinator(selector), do: selector.combinator
+end

--- a/lib/meeseeks/selector/root.ex
+++ b/lib/meeseeks/selector/root.ex
@@ -1,0 +1,19 @@
+defmodule Meeseeks.Selector.Root do
+  @moduledoc false
+
+  use Meeseeks.Selector
+
+  alias Meeseeks.Selector
+
+  defstruct selectors: [], combinator: nil
+
+  def match?(selector, %{parent: nil} = node, document) do
+    Enum.all?(selector.selectors, &(Selector.match? &1, node, document))
+  end
+
+  def match?(_selector, _node, _document) do
+    false
+  end
+
+  def combinator(selector), do: selector.combinator
+end

--- a/lib/meeseeks/selector/root.ex
+++ b/lib/meeseeks/selector/root.ex
@@ -4,16 +4,23 @@ defmodule Meeseeks.Selector.Root do
   use Meeseeks.Selector
 
   alias Meeseeks.Selector
+  alias Meeseeks.Selector.Root
 
-  defstruct selectors: [], combinator: nil
+  defstruct selectors: [], combinator: nil, filters: nil
 
-  def match?(selector, %{parent: nil} = node, document) do
-    Enum.all?(selector.selectors, &(Selector.match? &1, node, document))
+  def match(%Root{selectors: []}, %{parent: nil}, _document, _context) do
+    true
   end
 
-  def match?(_selector, _node, _document) do
+  def match(selector, %{parent: nil} = node, document, context) do
+    Enum.all?(selector.selectors, &(Selector.match &1, node, document, context))
+  end
+
+  def match(_selector, _node, _document, _context) do
     false
   end
 
   def combinator(selector), do: selector.combinator
+
+  def filters(selector), do: selector.filters
 end

--- a/lib/meeseeks/selector/xpath.ex
+++ b/lib/meeseeks/selector/xpath.ex
@@ -1,0 +1,16 @@
+defmodule Meeseeks.Selector.XPath do
+  @moduledoc false
+
+  alias Meeseeks.Selector.XPath.{Parser, Transpiler, Tokenizer}
+
+  def compile_selectors(selectors_string) do
+    selectors_string
+    |> Tokenizer.tokenize()
+    |> Parser.parse_expression()
+    |> Transpiler.to_selectors()
+    |> unwrap_single_selector()
+  end
+
+  defp unwrap_single_selector([selector]), do: selector
+  defp unwrap_single_selector(selectors), do: selectors
+end

--- a/lib/meeseeks/selector/xpath/combinator/attributes.ex
+++ b/lib/meeseeks/selector/xpath/combinator/attributes.ex
@@ -1,0 +1,17 @@
+defmodule Meeseeks.Selector.XPath.Combinator.Attributes do
+  @moduledoc false
+
+  use Meeseeks.Selector.Combinator
+
+  alias Meeseeks.Document
+
+  defstruct selector: nil
+
+  def next(_combinator, %Document.Element{} = element, _document) do
+    element.attributes
+  end
+
+  def next(_combinator, _node, _document) do
+    nil
+  end
+end

--- a/lib/meeseeks/selector/xpath/combinator/namespaces.ex
+++ b/lib/meeseeks/selector/xpath/combinator/namespaces.ex
@@ -1,0 +1,17 @@
+defmodule Meeseeks.Selector.XPath.Combinator.Namespaces do
+  @moduledoc false
+
+  use Meeseeks.Selector.Combinator
+
+  alias Meeseeks.Document
+
+  defstruct selector: nil
+
+  def next(_combinator, %Document.Element{} = element, _document) do
+    element.namespace
+  end
+
+  def next(_combinator, _node, _document) do
+    nil
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr.ex
+++ b/lib/meeseeks/selector/xpath/expr.ex
@@ -1,0 +1,35 @@
+defmodule Meeseeks.Selector.XPath.Expr do
+  @moduledoc false
+
+  alias Meeseeks.{Context, Document}
+  alias Meeseeks.Selector.XPath
+
+  @type t :: struct
+
+  @doc """
+  Invoked in order to evaluate the expression struct.
+  """
+  @callback eval(expr :: t, node :: Document.node_t, document :: Document.t, context :: Context.t) ::
+  any
+
+  # eval
+
+  @doc """
+  Evaluates the expression struct.
+  """
+  @spec eval(t, Document.node_t, Document.t, Context.t) :: any
+  def eval(%{__struct__: struct} = expr, node, document, context) do
+    struct.eval(expr, node, document, context)
+  end
+
+  # __using__
+
+  @doc false
+  defmacro __using__(_) do
+    quote do
+      @behaviour XPath.Expr
+      def eval(_, _, _, _), do: raise "eval/4 not implemented"
+      defoverridable eval: 4
+    end
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/arithmetic.ex
+++ b/lib/meeseeks/selector/xpath/expr/arithmetic.ex
@@ -1,0 +1,49 @@
+defmodule Meeseeks.Selector.XPath.Expr.Arithmetic do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  alias Meeseeks.Selector.XPath.Expr
+
+  defstruct op: nil, e1: nil, e2: nil
+
+  def eval(%Expr.Arithmetic{op: :+} = expr, node, document, context) do
+    v1 = Expr.eval(expr.e1, node, document, context)
+    |> Expr.Helpers.number(document)
+    v2 = Expr.eval(expr.e2, node, document, context)
+    |> Expr.Helpers.number(document)
+    Expr.Helpers.add(v1, v2)
+  end
+
+  def eval(%Expr.Arithmetic{op: :-} = expr, node, document, context) do
+    v1 = Expr.eval(expr.e1, node, document, context)
+    |> Expr.Helpers.number(document)
+    v2 = Expr.eval(expr.e2, node, document, context)
+    |> Expr.Helpers.number(document)
+    Expr.Helpers.sub(v1, v2)
+  end
+
+  def eval(%Expr.Arithmetic{op: :*} = expr, node, document, context) do
+    v1 = Expr.eval(expr.e1, node, document, context)
+    |> Expr.Helpers.number(document)
+    v2 = Expr.eval(expr.e2, node, document, context)
+    |> Expr.Helpers.number(document)
+    Expr.Helpers.mult(v1, v2)
+  end
+
+  def eval(%Expr.Arithmetic{op: :div} = expr, node, document, context) do
+    v1 = Expr.eval(expr.e1, node, document, context)
+    |> Expr.Helpers.number(document)
+    v2 = Expr.eval(expr.e2, node, document, context)
+    |> Expr.Helpers.number(document)
+    Expr.Helpers.divd(v1, v2)
+  end
+
+  def eval(%Expr.Arithmetic{op: :mod} = expr, node, document, context) do
+    v1 = Expr.eval(expr.e1, node, document, context)
+    |> Expr.Helpers.number(document)
+    v2 = Expr.eval(expr.e2, node, document, context)
+    |> Expr.Helpers.number(document)
+    Expr.Helpers.mod(v1, v2)
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/attribute_name_test.ex
+++ b/lib/meeseeks/selector/xpath/expr/attribute_name_test.ex
@@ -1,0 +1,42 @@
+defmodule Meeseeks.Selector.XPath.Expr.AttributeNameTest do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  alias Meeseeks.Selector.XPath.Expr.AttributeNameTest
+
+  defstruct namespace: nil, name: nil
+
+  def eval(%AttributeNameTest{namespace: nil, name: "*"}, {_attr, _val}, _document, _context) do
+    true
+  end
+
+  def eval(%AttributeNameTest{namespace: ns, name: "*"}, {attr, _val}, _document, _context) do
+    case String.split(attr, ":", parts: 2) do
+      [_name] -> false
+      [namespace, _name] -> namespace == ns
+    end
+  end
+
+  def eval(%AttributeNameTest{namespace: ns, name: nil}, {attr, _val}, _document, _context) do
+    case String.split(attr, ":", parts: 2) do
+      [_name] -> false
+      [namespace, _name] -> namespace == ns
+    end
+  end
+
+  def eval(%AttributeNameTest{namespace: nil, name: name}, {attr, _val}, _document, _context) do
+    case String.split(attr, ":", parts: 2) do
+      [local_name] -> local_name == name
+      [_namespace, local_name] -> local_name == name
+    end
+  end
+
+  def eval(%AttributeNameTest{namespace: ns, name: name}, {attr, _val}, _document, _context) do
+    attr == ns <> ":" <> name
+  end
+
+  def eval(_expr, _element, _document, _context) do
+    false
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/boolean.ex
+++ b/lib/meeseeks/selector/xpath/expr/boolean.ex
@@ -1,0 +1,31 @@
+defmodule Meeseeks.Selector.XPath.Expr.Boolean do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  alias Meeseeks.Selector.XPath.Expr
+
+  defstruct op: nil, e1: nil, e2: nil
+
+  def eval(%Expr.Boolean{op: :or} = expr, node, document, context) do
+    v1 = Expr.eval(expr.e1, node, document, context)
+    |> Expr.Helpers.boolean(document)
+    if v1 do
+      true
+    else
+      Expr.eval(expr.e2, node, document, context)
+      |> Expr.Helpers.boolean(document)
+    end
+  end
+
+  def eval(%Expr.Boolean{op: :and} = expr, node, document, context) do
+    v1 = Expr.eval(expr.e1, node, document, context)
+    |> Expr.Helpers.boolean(document)
+    if v1 do
+      Expr.eval(expr.e2, node, document, context)
+      |> Expr.Helpers.boolean(document)
+    else
+      false
+    end
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/comparative.ex
+++ b/lib/meeseeks/selector/xpath/expr/comparative.ex
@@ -1,0 +1,56 @@
+defmodule Meeseeks.Selector.XPath.Expr.Comparative do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  alias Meeseeks.Selector.XPath.Expr
+
+  defstruct op: nil, e1: nil, e2: nil
+
+  def eval(%Expr.Comparative{op: :=} = expr, node, document, context) do
+    v1 = Expr.eval(expr.e1, node, document, context)
+    v2 = Expr.eval(expr.e2, node, document, context)
+    compare(
+      expr.op,
+      Expr.Helpers.eq_fmt(v1, v2, document),
+      Expr.Helpers.eq_fmt(v2, v1, document)
+    )
+  end
+
+  def eval(%Expr.Comparative{op: :!=} = expr, node, document, context) do
+    v1 = Expr.eval(expr.e1, node, document, context)
+    v2 = Expr.eval(expr.e2, node, document, context)
+    compare(
+      expr.op,
+      Expr.Helpers.eq_fmt(v1, v2, document),
+      Expr.Helpers.eq_fmt(v2, v1, document)
+    )
+  end
+
+  def eval(expr, node, document, context) do
+    v1 = Expr.eval(expr.e1, node, document, context)
+    v2 = Expr.eval(expr.e2, node, document, context)
+    compare(
+      expr.op,
+      Expr.Helpers.cmp_fmt(v1, v2, document),
+      Expr.Helpers.cmp_fmt(v2, v1, document)
+    )
+  end
+
+  def compare(op, x, y) when is_list(x) and is_list(y) do
+    Enum.any?(x, fn(xv) ->
+      Enum.any?(y, fn(yv) ->
+        Expr.Helpers.compare(op, xv, yv)
+      end)
+    end)
+  end
+  def compare(op, x, y) when is_list(x) do
+    Enum.any?(x, fn(xv) -> Expr.Helpers.compare(op, xv, y) end)
+  end
+  def compare(op, x, y) when is_list(y) do
+    Enum.any?(y, fn(yv) -> Expr.Helpers.compare(op, x, yv) end)
+  end
+  def compare(op, x, y) do
+    Expr.Helpers.compare(op, x, y)
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/filter.ex
+++ b/lib/meeseeks/selector/xpath/expr/filter.ex
@@ -1,0 +1,22 @@
+defmodule Meeseeks.Selector.XPath.Expr.Filter do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  alias Meeseeks.Context
+  alias Meeseeks.Selector.XPath.Expr
+
+  @nodes Context.nodes_key()
+
+  defstruct e: nil, predicate: nil
+
+  def eval(expr, node, document, context) do
+    v = Expr.eval(expr.e, node, document, context)
+    if Expr.Helpers.nodes?(v) do
+      context = Map.put(context, @nodes, v)
+      Enum.filter(v, &Expr.eval(expr.predicate, &1, document, context))
+    else
+      raise "Invalid evaluated argument to XPath filter: #{inspect(v)}"
+    end
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/function.ex
+++ b/lib/meeseeks/selector/xpath/expr/function.ex
@@ -1,0 +1,443 @@
+defmodule Meeseeks.Selector.XPath.Expr.Function do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  alias Meeseeks.{Context, Document}
+  alias Meeseeks.Selector.XPath.Expr
+
+  defstruct f: nil, args: []
+
+  @nodes Context.nodes_key()
+
+  # last
+
+  def eval(%Expr.Function{f: :last, args: []}, _node, _document, context) do
+    context
+    |> Map.fetch!(@nodes)
+    |> Enum.count()
+  end
+
+  def eval(%Expr.Function{f: :last, args: args}, _node, _document, _context) do
+    raise invalid_args("last", args)
+  end
+
+  # position
+
+  def eval(%Expr.Function{f: :position, args: []}, node, _document, context) do
+    Expr.Helpers.position(node, context)
+  end
+
+  def eval(%Expr.Function{f: :position, args: args}, _node, _document, _context) do
+    raise invalid_args("position", args)
+  end
+
+  # count
+
+  def eval(%Expr.Function{f: :count, args: [e]}, node, document, context) do
+    v = Expr.eval(e, node, document, context)
+    if Expr.Helpers.nodes?(v) do
+      Enum.count(v)
+    else
+      raise invalid_evaluated_args("count", [v])
+    end
+  end
+
+  def eval(%Expr.Function{f: :count, args: args}, _node, _document, _context) do
+    raise invalid_args("count", args)
+  end
+
+  # id not supported, if added would involve id attribute
+
+  # local-name
+
+  def eval(%Expr.Function{f: :"local-name", args: []}, node, _document, _context) do
+    local_name(node)
+  end
+
+  def eval(%Expr.Function{f: :"local-name", args: [e]}, node, document, context) do
+    v = Expr.eval(e, node, document, context)
+    if Expr.Helpers.nodes?(v) do
+      [node|_] = v
+      local_name(node)
+    else
+      raise invalid_evaluated_args("local-name", [v])
+    end
+  end
+
+  def eval(%Expr.Function{f: :"local-name", args: args}, _node, _document, _context) do
+    raise invalid_args("local-name", args)
+  end
+
+  # namespace-uri
+
+  ## Currently returns namespace prefix, not full namespace uri.
+
+  def eval(%Expr.Function{f: :"namespace-uri", args: []}, node, _document, _context) do
+    namespace_uri(node)
+  end
+
+  def eval(%Expr.Function{f: :"namespace-uri", args: [e]}, node, document, context) do
+    v = Expr.eval(e, node, document, context)
+    if Expr.Helpers.nodes?(v) do
+      [node|_] = v
+      namespace_uri(node)
+    else
+      raise invalid_evaluated_args("namespace-uri", [v])
+    end
+  end
+
+  def eval(%Expr.Function{f: :"namespace-uri", args: args}, _node, _document, _context) do
+    raise invalid_args("namespace-uri", args)
+  end
+
+  # name
+
+  def eval(%Expr.Function{f: :name, args: []}, node, _document, _context) do
+    name(node)
+  end
+
+  def eval(%Expr.Function{f: :name, args: [e]}, node, document, context) do
+    v = Expr.eval(e, node, document, context)
+    if Expr.Helpers.nodes?(v) do
+      [node|_] = v
+      name(node)
+    else
+      raise invalid_evaluated_args("name", [v])
+    end
+  end
+
+  def eval(%Expr.Function{f: :name, args: args}, _node, _document, _context) do
+    raise invalid_args("name", args)
+  end
+
+  # string
+
+  def eval(%Expr.Function{f: :string, args: []}, node, document, _context) do
+    Expr.Helpers.string([node], document)
+  end
+
+  def eval(%Expr.Function{f: :string, args: [e]}, node, document, context) do
+    Expr.eval(e, node, document, context)
+    |> Expr.Helpers.string(document)
+  end
+
+  def eval(%Expr.Function{f: :string, args: args}, _node, _document, _context) do
+    raise invalid_args("string", args)
+  end
+
+  # concat
+
+  def eval(%Expr.Function{f: :concat, args: [_, _|_] = args}, node, document, context) do
+    args
+    |> Enum.map(&Expr.eval(&1, node, document, context))
+    |> Enum.map(&Expr.Helpers.string(&1, document))
+    |> Enum.join("")
+  end
+
+  def eval(%Expr.Function{f: :concat, args: args}, _node, _document, _context) do
+    raise invalid_args("concat", args)
+  end
+
+  # starts-with
+
+  def eval(%Expr.Function{f: :"starts-with", args: [e1, e2]}, node, document, context) do
+    v1 = Expr.eval(e1, node, document, context)
+    |> Expr.Helpers.string(document)
+    v2 = Expr.eval(e2, node, document, context)
+    |> Expr.Helpers.string(document)
+    String.starts_with?(v1, v2)
+  end
+
+  def eval(%Expr.Function{f: :"starts-with", args: args}, _node, _document, _context) do
+    raise invalid_args("starts-with", args)
+  end
+
+  # contains
+
+  def eval(%Expr.Function{f: :contains, args: [e1, e2]}, node, document, context) do
+    v1 = Expr.eval(e1, node, document, context)
+    |> Expr.Helpers.string(document)
+    v2 = Expr.eval(e2, node, document, context)
+    |> Expr.Helpers.string(document)
+    String.contains?(v1, v2)
+  end
+
+  def eval(%Expr.Function{f: :contains, args: args}, _node, _document, _context) do
+    raise invalid_args("contains", args)
+  end
+
+  # substring-before
+
+  def eval(%Expr.Function{f: :"substring-before", args: [e1, e2]}, node, document, context) do
+    v1 = Expr.eval(e1, node, document, context)
+    |> Expr.Helpers.string(document)
+    v2 = Expr.eval(e2, node, document, context)
+    |> Expr.Helpers.string(document)
+    case String.split(v1, v2, parts: 2) do
+      [_] -> ""
+      [substring_before, _] -> substring_before
+    end
+  end
+
+  def eval(%Expr.Function{f: :"substring-before", args: args}, _node, _document, _context) do
+    raise invalid_args("substring-before", args)
+  end
+
+  # substring-after
+
+  def eval(%Expr.Function{f: :"substring-after", args: [e1, e2]}, node, document, context) do
+    v1 = Expr.eval(e1, node, document, context)
+    |> Expr.Helpers.string(document)
+    v2 = Expr.eval(e2, node, document, context)
+    |> Expr.Helpers.string(document)
+    case String.split(v1, v2, parts: 2) do
+      [_] -> ""
+      [_, substring_after] -> substring_after
+    end
+  end
+
+  def eval(%Expr.Function{f: :"substring-after", args: args}, _node, _document, _context) do
+    raise invalid_args("substring-after", args)
+  end
+
+  # substring
+
+  def eval(%Expr.Function{f: :substring, args: [e1, e2]}, node, document, context) do
+    v1 = Expr.eval(e1, node, document, context)
+    |> Expr.Helpers.string(document)
+    v2 = Expr.eval(e2, node, document, context)
+    |> Expr.Helpers.number(document)
+    |> Expr.Helpers.round_()
+    # First index is 1, not 0, so subtract 1
+    |> Expr.Helpers.sub(1)
+    Expr.Helpers.substring(v1, v2)
+  end
+
+  def eval(%Expr.Function{f: :substring, args: [e1, e2, e3]}, node, document, context) do
+    v1 = Expr.eval(e1, node, document, context)
+    |> Expr.Helpers.string(document)
+    v2 = Expr.eval(e2, node, document, context)
+    |> Expr.Helpers.number(document)
+    |> Expr.Helpers.round_()
+    # First index is 1, not 0, so subtract 1
+    |> Expr.Helpers.sub(1)
+    v3 = Expr.eval(e3, node, document, context)
+    |> Expr.Helpers.number(document)
+    |> Expr.Helpers.round_()
+    Expr.Helpers.substring(v1, v2, v3)
+  end
+
+  def eval(%Expr.Function{f: :substring, args: args}, _node, _document, _context) do
+    raise invalid_args("substring", args)
+  end
+
+  # string-length
+
+  def eval(%Expr.Function{f: :"string-length", args: []}, node, document, _context) do
+    [node]
+    |> Expr.Helpers.string(document)
+    |> String.length()
+  end
+
+  def eval(%Expr.Function{f: :"string-length", args: [e]}, node, document, context) do
+    Expr.eval(e, node, document, context)
+    |> Expr.Helpers.string(document)
+    |> String.length()
+  end
+
+  def eval(%Expr.Function{f: :"string-length", args: args}, _node, _document, _context) do
+    raise invalid_args("string-length", args)
+  end
+
+  # normalize-space
+
+  def eval(%Expr.Function{f: :"normalize-space", args: []}, node, document, _context) do
+    [node]
+    |> Expr.Helpers.string(document)
+    |> normalize_whitespace()
+  end
+
+  def eval(%Expr.Function{f: :"normalize-space", args: [e]}, node, document, context) do
+    Expr.eval(e, node, document, context)
+    |> Expr.Helpers.string(document)
+    |> normalize_whitespace()
+  end
+
+  def eval(%Expr.Function{f: :"normalize-space", args: args}, _node, _document, _context) do
+    raise invalid_args("normalize-space", args)
+  end
+
+  # translate not supported
+
+  # boolean
+
+  def eval(%Expr.Function{f: :boolean, args: [e]}, node, document, context) do
+    Expr.eval(e, node, document, context)
+    |> Expr.Helpers.boolean(document)
+  end
+
+  def eval(%Expr.Function{f: :boolean, args: args}, _node, _document, _context) do
+    raise invalid_args("boolean", args)
+  end
+
+  # not
+
+  def eval(%Expr.Function{f: :not, args: [e]}, node, document, context) do
+    Expr.eval(e, node, document, context)
+    |> Expr.Helpers.boolean(document)
+    |> not_()
+  end
+
+  def eval(%Expr.Function{f: :not, args: args}, _node, _document, _context) do
+    raise invalid_args("not", args)
+  end
+
+  # true
+
+  def eval(%Expr.Function{f: :true, args: []}, _node, _document, _context) do
+    true
+  end
+
+  def eval(%Expr.Function{f: :true, args: args}, _node, _document, _context) do
+    raise invalid_args("true", args)
+  end
+
+  # false
+
+  def eval(%Expr.Function{f: :false, args: []}, _node, _document, _context) do
+    false
+  end
+
+  def eval(%Expr.Function{f: :false, args: args}, _node, _document, _context) do
+    raise invalid_args("false", args)
+  end
+
+  # lang not supported
+
+  # number
+
+  def eval(%Expr.Function{f: :number, args: []}, node, document, _context) do
+    [node]
+    |> Expr.Helpers.number(document)
+  end
+
+  def eval(%Expr.Function{f: :number, args: [e]}, node, document, context) do
+    Expr.eval(e, node, document, context)
+    |> Expr.Helpers.number(document)
+  end
+
+  def eval(%Expr.Function{f: :number, args: args}, _node, _document, _context) do
+    raise invalid_args("number", args)
+  end
+
+  # sum
+
+  def eval(%Expr.Function{f: :sum, args: [e]}, node, document, context) do
+    v = Expr.eval(e, node, document, context)
+    if Expr.Helpers.nodes?(v) do
+      Enum.reduce(v, 0, fn(node, sum) ->
+        node
+        |> Expr.Helpers.string(document)
+        |> Expr.Helpers.number(document)
+        |> Expr.Helpers.add(sum)
+      end)
+    else
+      raise invalid_evaluated_args("sum", [v])
+    end
+  end
+
+  def eval(%Expr.Function{f: :sum, args: args}, _node, _document, _context) do
+    raise invalid_args("sum", args)
+  end
+
+  # floor
+
+  def eval(%Expr.Function{f: :floor, args: [e]}, node, document, context) do
+    Expr.eval(e, node, document, context)
+    |> Expr.Helpers.number(document)
+    |> Expr.Helpers.floor()
+  end
+
+  def eval(%Expr.Function{f: :floor, args: args}, _node, _document, _context) do
+    raise invalid_args("floor", args)
+  end
+
+  # ceiling
+
+  def eval(%Expr.Function{f: :ceiling, args: [e]}, node, document, context) do
+    Expr.eval(e, node, document, context)
+    |> Expr.Helpers.number(document)
+    |> Expr.Helpers.ceiling()
+  end
+
+  def eval(%Expr.Function{f: :ceiling, args: args}, _node, _document, _context) do
+    raise invalid_args("ceiling", args)
+  end
+
+  # round
+
+  def eval(%Expr.Function{f: :round, args: [e]}, node, document, context) do
+    Expr.eval(e, node, document, context)
+    |> Expr.Helpers.number(document)
+    |> Expr.Helpers.round_()
+  end
+
+  def eval(%Expr.Function{f: :round, args: args}, _node, _document, _context) do
+    raise invalid_args("round", args)
+  end
+
+  # unknown function
+
+  def eval(%Expr.Function{f: f} = _expr, _node, _document, _context) do
+    raise "XPath function #{f} is unknown"
+  end
+
+  # helpers
+
+  defp invalid_args(f, args) do
+    "Invalid arguments to XPath function #{f}: #{inspect(args)}"
+  end
+
+  defp invalid_evaluated_args(f, args) do
+    "Invalid evaluated arguments to XPath function #{f}: #{inspect(args)}"
+  end
+
+  defp local_name(%Document.Element{tag: local_name}), do: local_name
+  defp local_name({attr, _value}) do
+    case String.split(attr, ":", parts: 2) do
+      [name] -> name
+      [_namespace, name] -> name
+    end
+  end
+  defp local_name(namespace) when is_binary(namespace), do: namespace
+  defp local_name(_), do: ""
+
+  defp namespace_uri(%Document.Element{namespace: ns_uri}), do: ns_uri
+  defp namespace_uri({attr, _value}) do
+    case String.split(attr, ":", parts: 2) do
+      [_name] -> ""
+      [namespace, _name] -> namespace
+    end
+  end
+  defp namespace_uri(_), do: ""
+
+  defp name(%Document.Element{} = element) do
+    case [element.namespace, element.tag] do
+      ["",  ""] -> ""
+      ["", local_name] -> local_name
+      [ns_uri, local_name] -> ns_uri <> ":" <> local_name
+    end
+  end
+  defp name({attr, _value}), do: attr
+  defp name(namespace) when is_binary(namespace), do: namespace
+  defp name(_), do: ""
+
+  defp normalize_whitespace(s) do
+    s
+    |> String.trim()
+    |> String.replace(~r/[\s]+/, " ")
+  end
+
+  defp not_(b) when is_boolean(b), do: not(b)
+end

--- a/lib/meeseeks/selector/xpath/expr/helpers.ex
+++ b/lib/meeseeks/selector/xpath/expr/helpers.ex
@@ -1,0 +1,337 @@
+defmodule Meeseeks.Selector.XPath.Expr.Helpers do
+  @moduledoc false
+
+  alias Meeseeks.{Context, Document}
+
+  @nodes Context.nodes_key()
+  @other_nums [:NaN, :Infinity, :"-Infinity"]
+
+  # eq_fmt
+
+  def eq_fmt(x, y, document) when is_list(x) or is_list(y) do
+    nodes_fmt(x, y, document)
+  end
+  def eq_fmt(x, y, document) when is_boolean(x) or is_boolean(y) do
+    boolean(x, document)
+  end
+  def eq_fmt(x, y, document) when is_number(x) or is_number(y) do
+    number(x, document)
+  end
+  def eq_fmt(x, y, document) when x in @other_nums or y in @other_nums do
+    number(x, document)
+  end
+  def eq_fmt(x, _y, document) do
+    string(x, document)
+  end
+
+  # cmp_fmt
+
+  def cmp_fmt(x, y, document) when is_list(x) or is_list(y) do
+    nodes_fmt(x, y, document)
+  end
+  def cmp_fmt(x, _y, document) do
+    number(x, document)
+  end
+
+  # nodes_fmt
+
+  defp nodes_fmt(x, _y, _document) when is_number(x) do
+    x
+  end
+  defp nodes_fmt(x, _y, _document) when x in @other_nums do
+    x
+  end
+  defp nodes_fmt(x, _y, _document) when is_boolean(x) do
+    x
+  end
+  defp nodes_fmt(x, _y, _document) when is_binary(x) do
+    x
+  end
+  defp nodes_fmt(x, y, document) when is_list(x) and is_number(y) do
+    Enum.map(x, &(string(&1, document) |> number(document)))
+  end
+  defp nodes_fmt(x, y, document) when is_list(x) and y in @other_nums do
+    Enum.map(x, &(string(&1, document) |> number(document)))
+  end
+  defp nodes_fmt(x, y, document) when is_list(x) and is_boolean(y) do
+    boolean(x, document)
+  end
+  defp nodes_fmt(x, y, document) when is_list(x) and is_binary(y) do
+    Enum.map(x, &string(&1, document))
+  end
+  defp nodes_fmt(x, y, document) when is_list(x) and is_list(y) do
+    Enum.map(x, &string(&1, document))
+  end
+
+  # boolean
+
+  def boolean(false, _document), do: false
+  def boolean(true, _document), do: true
+  def boolean("", _document), do: false
+  def boolean([], _document), do: false
+  def boolean(:NaN, _document), do: false
+  def boolean(:Infinity, _document), do: true
+  def boolean(:"-Infinity", _document), do: true
+  def boolean(x, _document) when is_binary(x), do: true
+  def boolean(x, _document) when is_integer(x), do: x != 0
+  def boolean(x, _document) when is_float(x), do: x != 0.0
+  def boolean(x, _document) when is_list(x), do: nodes?(x)
+  def boolean(x, _document), do: raise ArgumentError, arg_error("boolean", x)
+
+  # number
+
+  def number(false, _document), do: 0
+  def number(true, _document), do: 1
+  def number("", _document), do: :NaN
+  def number([], _document), do: :NaN
+  def number(:NaN, _document), do: :NaN
+  def number(:Infinity, _document), do: :Infinity
+  def number(:"-Infinity", _document), do: :"-Infinity"
+  def number(x, _document) when is_number(x), do: x
+  def number(x, document) when is_list(x), do: string(x, document) |> number(document)
+  def number(x, _document) when is_binary(x) do
+    case Regex.run(~r/^\s*(\-?\d+(\.\d+)?)\s*$/, x) do
+      [_, s] -> String.to_integer(s)
+      [_, s, _] -> String.to_float(s)
+      _ -> :NaN
+    end
+  end
+  def number(x, _document), do: raise ArgumentError, arg_error("number", x)
+
+  # string
+
+  def string(false, _document), do: "false"
+  def string(true, _document), do: "true"
+  def string([], _document), do: ""
+  def string(0, _document), do: "0"
+  def string(0.0, _document), do: "0"
+  def string(:NaN, _document), do: "NaN"
+  def string(:Infinity, _document), do: "Infinity"
+  def string(:"-Infinity", _document), do: "-Infinity"
+  def string({_attr, value}, _document), do: value
+  def string(%Document.Doctype{}, _document), do: ""
+  def string(%Document.Comment{} = x, _document), do: x.content
+  def string(%Document.Data{} = x, _document), do: x.content
+  def string(%Document.Text{} = x, _document), do: x.content
+  def string(%Document.Element{} = x, document) do
+    children = Document.children(document, x.id)
+    child_nodes = Document.get_nodes(document, children)
+    child_nodes
+    |> Enum.map(&string(&1, document))
+    |> Enum.join("")
+  end
+  def string(x, _document) when is_binary(x), do: x
+  def string(x, _document) when is_integer(x), do: Integer.to_string(x)
+  def string(x, _document) when is_float(x), do: Float.to_string(x)
+  def string(x, document) when is_list(x) do
+    if nodes?(x) do
+      [node|_] = x
+      string(node, document)
+    else
+      raise ArgumentError, arg_error("string", x)
+    end
+  end
+  def string(x, _document), do: raise ArgumentError, arg_error("string", x)
+
+  # nodes?
+
+  def nodes?(xs) when is_list(xs), do: Enum.all?(xs, &node?/1)
+  def nodes?(_), do: false
+
+  # node?
+
+  def node?(%Document.Comment{}), do: true
+  def node?(%Document.Data{}), do: true
+  def node?(%Document.Doctype{}), do: true
+  def node?(%Document.Element{}), do: true
+  def node?(%Document.Text{}), do: true
+  # attribute
+  def node?({attr, val}) when is_binary(attr) and is_binary(val), do: true
+  # namespace
+  def node?(ns) when is_binary(ns), do: true
+  def node?(_), do: false
+
+  # position
+
+  def position(node, context) do
+    context
+    |> Map.fetch!(@nodes)
+    |> Enum.find_index(fn(n) -> node == n end)
+    |> plus_one()
+  end
+
+  # substring/2
+
+  def substring(_s, :NaN), do: ""
+  def substring(_s, :Infinity), do: ""
+  def substring(s, :"-Infinity"), do: s
+  def substring(s, n) when n <= 0, do: s
+  def substring(s, n) do
+    {_, sub} = String.split_at(s, n)
+    sub
+  end
+
+  # substring/3
+
+  def substring(_s, :NaN, _n2), do: ""
+  def substring(_s, _n1, :NaN), do: ""
+  def substring(_s, :Infinity, _n2), do: ""
+  def substring(s, :"-Infinity", :Infinity), do: s
+  def substring(s, :"-Infinity", n2), do: String.slice(s, 0, n2)
+  def substring(s, n1, n2) when n1 <= 0 do
+    case n2 do
+      :"-Infinity" -> ""
+      :Infinity -> String.slice(s, 0, String.length(s))
+      _ ->
+        len = n1 + n2
+        if len <= 0 do
+          ""
+        else
+          String.slice(s, 0, len)
+        end
+    end
+  end
+  def substring(s, n1, n2) do
+    case n2 do
+      :"-Infinity" -> ""
+      :Infinity -> String.slice(s, n1, String.length(s))
+      _ ->
+        if n2 <= 0 do
+          ""
+        else
+          String.slice(s, n1, n2)
+        end
+
+    end
+  end
+
+  # arithmetic
+
+  def add(:NaN, _), do: :NaN
+  def add(_, :NaN), do: :NaN
+  def add(:Infinity, _), do: :Infinity
+  def add(_, :Infinity), do: :Infinity
+  def add(:"-Infinity", _), do: :"-Infinity"
+  def add(_, :"-Infinity"), do: :"-Infinity"
+  def add(n1, n2), do: n1 + n2
+
+  def sub(:NaN, _), do: :NaN
+  def sub(_, :NaN), do: :NaN
+  def sub(:Infinity, _), do: :Infinity
+  def sub(_, :Infinity), do: :Infinity
+  def sub(:"-Infinity", _), do: :"-Infinity"
+  def sub(_, :"-Infinity"), do: :"-Infinity"
+  def sub(n1, n2), do: n1 - n2
+
+  def mult(:NaN, _), do: :NaN
+  def mult(_, :NaN), do: :NaN
+  def mult(:Infinity, _), do: :Infinity
+  def mult(_, :Infinity), do: :Infinity
+  def mult(:"-Infinity", _), do: :"-Infinity"
+  def mult(_, :"-Infinity"), do: :"-Infinity"
+  def mult(n1, n2), do: n1 * n2
+
+  def divd(:NaN, _), do: :NaN
+  def divd(_, :NaN), do: :NaN
+  def divd(:Infinity, _), do: :Infinity
+  def divd(_, :Infinity), do: :Infinity
+  def divd(:"-Infinity", _), do: :"-Infinity"
+  def divd(_, :"-Infinity"), do: :"-Infinity"
+  def divd(_, 0), do: :Infinity
+  def divd(n1, n2), do: div(n1, n2)
+
+  def mod(:NaN, _), do: :NaN
+  def mod(_, :NaN), do: :NaN
+  def mod(:Infinity, _), do: :Infinity
+  def mod(_, :Infinity), do: :Infinity
+  def mod(:"-Infinity", _), do: :"-Infinity"
+  def mod(_, :"-Infinity"), do: :"-Infinity"
+  def mod(_, 0), do: :Infinity
+  def mod(n1, n2), do: rem(n1, n2)
+
+  # numbers
+
+  def round_(:NaN), do: :NaN
+  def round_(:Infinity), do: :Infinity
+  def round_(:"-Infinity"), do: :"-Infinity"
+  def round_(n) when is_float(n), do: round(n)
+  def round_(n) when is_integer(n), do: n
+
+  def floor(:NaN), do: :NaN
+  def floor(:Infinity), do: :Infinity
+  def floor(:"-Infinity"), do: :"-Infinity"
+  def floor(n) when is_float(n), do: Float.floor(n)
+  def floor(n) when is_integer(n), do: n
+
+  def ceiling(:NaN), do: :NaN
+  def ceiling(:Infinity), do: :Infinity
+  def ceiling(:"-Infinity"), do: :"-Infinity"
+  def ceiling(n) when is_float(n), do: Float.ceil(n)
+  def ceiling(n) when is_integer(n), do: n
+
+  # compare
+
+  # =
+  def compare(:=, x, y), do: x == y
+  # !=
+  def compare(:!=, x, y), do: x != y
+  # <=
+  def compare(:<=, :NaN, :NaN), do: true
+  def compare(:<=, :NaN, _), do: true
+  def compare(:<=, _, :NaN), do: false
+  def compare(:<=, :Infinity, :Infinity), do: true
+  def compare(:<=, :Infinity, _), do: false
+  def compare(:<=, _, :Infinity), do: true
+  def compare(:<=, :"-Infinity", :"-Infinity"), do: true
+  def compare(:<=, :"-Infinity", _), do: true
+  def compare(:<=, _, :"-Infinity"), do: false
+  def compare(:<=, x, y), do: x <= y
+  # <
+  def compare(:<, :NaN, :NaN), do: false
+  def compare(:<, :NaN, _), do: true
+  def compare(:<, _, :NaN), do: false
+  def compare(:<, :Infinity, :Infinity), do: false
+  def compare(:<, :Infinity, _), do: false
+  def compare(:<, _, :Infinity), do: true
+  def compare(:<, :"-Infinity", :"-Infinity"), do: false
+  def compare(:<, :"-Infinity", _), do: true
+  def compare(:<, _, :"-Infinity"), do: false
+  def compare(:<, x, y), do: x < y
+  # >=
+  def compare(:>=, :NaN, :NaN), do: true
+  def compare(:>=, :NaN, _), do: false
+  def compare(:>=, _, :NaN), do: true
+  def compare(:>=, :Infinity, :Infinity), do: true
+  def compare(:>=, :Infinity, _), do: true
+  def compare(:>=, _, :Infinity), do: false
+  def compare(:>=, :"-Infinity", :"-Infinity"), do: true
+  def compare(:>=, :"-Infinity", _), do: false
+  def compare(:>=, _, :"-Infinity"), do: true
+  def compare(:>=, x, y), do: x >= y
+  # >
+  def compare(:>, :NaN, :NaN), do: false
+  def compare(:>, :NaN, _), do: false
+  def compare(:>, _, :NaN), do: true
+  def compare(:>, :Infinity, :Infinity), do: false
+  def compare(:>, :Infinity, _), do: true
+  def compare(:>, _, :Infinity), do: false
+  def compare(:>, :"-Infinity", :"-Infinity"), do: false
+  def compare(:>, :"-Infinity", _), do: false
+  def compare(:>, _, :"-Infinity"), do: true
+  def compare(:>, x, y), do: x > y
+
+  # negate
+
+  def negate(:NaN), do: :NaN
+  def negate(:Infinity), do: :"-Infinity"
+  def negate(:"-Infinity"), do: :Infinity
+  def negate(n), do: - n
+
+  # misc
+
+  defp arg_error(f, arg) do
+    "Meeseeks.Selector.XPath.Expr.Helpers.#{f}(#{inspect(arg)})"
+  end
+
+  defp plus_one(n), do: n + 1
+end

--- a/lib/meeseeks/selector/xpath/expr/literal.ex
+++ b/lib/meeseeks/selector/xpath/expr/literal.ex
@@ -1,0 +1,11 @@
+defmodule Meeseeks.Selector.XPath.Expr.Literal do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  defstruct value: ""
+
+  def eval(expr, _node, _document, _context) do
+    expr.value
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/name_test.ex
+++ b/lib/meeseeks/selector/xpath/expr/name_test.ex
@@ -1,0 +1,34 @@
+defmodule Meeseeks.Selector.XPath.Expr.NameTest do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.XPath.Expr.NameTest
+
+  defstruct namespace: nil, tag: nil
+
+  def eval(%NameTest{namespace: nil, tag: "*"}, %Document.Element{}, _document, _context) do
+    true
+  end
+
+  def eval(%NameTest{namespace: ns, tag: "*"}, %Document.Element{} = element, _document, _context) do
+    element.namespace == ns
+  end
+
+  def eval(%NameTest{namespace: ns, tag: nil}, %Document.Element{} = element, _document, _context) do
+    element.namespace == ns
+  end
+
+  def eval(%NameTest{namespace: nil, tag: tag}, %Document.Element{} = element, _document, _context) do
+    element.tag == tag
+  end
+
+  def eval(%NameTest{namespace: ns, tag: tag}, %Document.Element{} = element, _document, _context) do
+    element.namespace == ns and element.tag == tag
+  end
+
+  def eval(_expr, _element, _document, _context) do
+    false
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/namespace_name_test.ex
+++ b/lib/meeseeks/selector/xpath/expr/namespace_name_test.ex
@@ -1,0 +1,30 @@
+defmodule Meeseeks.Selector.XPath.Expr.NamespaceNameTest do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  alias Meeseeks.Selector.XPath.Expr.NamespaceNameTest
+
+  # Not currently resolving prefix to namespace-uri
+
+  # Name == namespace, namespace should always be empty or nil
+  defstruct namespace: nil, name: nil
+
+  def eval(%NamespaceNameTest{namespace: nil, name: "*"}, _ns, _document, _context) do
+    true
+  end
+
+  def eval(%NamespaceNameTest{namespace: nil, name: name}, ns, _document, _context) do
+
+    name == ns
+  end
+
+  def eval(%NamespaceNameTest{namespace: "", name: name}, ns, _document, _context) do
+
+    name == ns
+  end
+
+  def eval(_expr, _element, _document, _context) do
+    false
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/negative.ex
+++ b/lib/meeseeks/selector/xpath/expr/negative.ex
@@ -1,0 +1,15 @@
+defmodule Meeseeks.Selector.XPath.Expr.Negative do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  alias Meeseeks.Selector.XPath.Expr
+
+  defstruct e: nil
+
+  def eval(expr, node, document, context) do
+    Expr.eval(expr.e, node, document, context)
+    |> Expr.Helpers.number(document)
+    |> Expr.Helpers.negate()
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/node_type.ex
+++ b/lib/meeseeks/selector/xpath/expr/node_type.ex
@@ -1,0 +1,34 @@
+defmodule Meeseeks.Selector.XPath.Expr.NodeType do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.XPath.Expr.NodeType
+
+  defstruct type: nil
+
+  def eval(%NodeType{type: :comment}, %Document.Comment{}, _document, _context) do
+    true
+  end
+
+  def eval(%NodeType{type: :node}, _node, _document, _context) do
+    true
+  end
+
+  def eval(%NodeType{type: :"processing-instruction"}, _node, _document, _context) do
+    false # currently not supported because html5ever will parse as comments
+  end
+
+  def eval(%NodeType{type: :text}, %Document.Data{}, _document, _context) do
+    true
+  end
+
+  def eval(%NodeType{type: :text}, %Document.Text{}, _document, _context) do
+    true
+  end
+
+  def eval(_expr, _node, _document, _context) do
+    false
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/number.ex
+++ b/lib/meeseeks/selector/xpath/expr/number.ex
@@ -1,0 +1,11 @@
+defmodule Meeseeks.Selector.XPath.Expr.Number do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  defstruct value: 0
+
+  def eval(expr, _node, _document, _context) do
+    expr.value
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/path.ex
+++ b/lib/meeseeks/selector/xpath/expr/path.ex
@@ -1,0 +1,47 @@
+defmodule Meeseeks.Selector.XPath.Expr.Path do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.XPath.Expr
+  alias Meeseeks.Selector.XPath.Expr.Path
+
+  defstruct type: nil, steps: []
+
+  def eval(%Path{type: :abs} = expr, _node, document, context) do
+    root_nodes = Document.get_nodes(document, document.roots)
+    next_step(expr.steps, root_nodes, document, context)
+  end
+
+  def eval(%Path{type: :rel} = expr, node, document, context) do
+    next_step(expr.steps, [node], document, context)
+  end
+
+  defp next_step(_steps, [], _document, _context) do
+    []
+  end
+
+  defp next_step([step|steps], nodes, document, context) when is_list(nodes) do
+    case steps do
+      [] ->
+        Enum.reduce(nodes, [], fn(node, nodes) ->
+          nodes ++ Expr.eval(step, node, document, context)
+        end)
+      steps ->
+        Enum.reduce(nodes, [], fn(node, nodes) ->
+          v = Expr.eval(step, node, document, context)
+          nodes ++ next_step(steps, v, document, context)
+        end)
+    end
+  end
+
+  defp next_step([step|steps], node, document, context) do
+    case steps do
+      [] -> Expr.eval(step, node, document, context)
+      steps ->
+        v = Expr.eval(step, node, document, context)
+        next_step(steps, v, document, context)
+    end
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/predicate.ex
+++ b/lib/meeseeks/selector/xpath/expr/predicate.ex
@@ -1,0 +1,19 @@
+defmodule Meeseeks.Selector.XPath.Expr.Predicate do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  alias Meeseeks.Selector.XPath.Expr
+
+  defstruct e: nil
+
+  def eval(expr, node, document, context) do
+    case Expr.eval(expr.e, node, document, context) do
+      :NaN -> false
+      :Infinity -> false
+      :"-Infinity" -> false
+      n when is_number(n) -> n == Expr.Helpers.position(node, context)
+      x -> Expr.Helpers.boolean(x, document)
+    end
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/processing_instruction.ex
+++ b/lib/meeseeks/selector/xpath/expr/processing_instruction.ex
@@ -1,0 +1,11 @@
+defmodule Meeseeks.Selector.XPath.Expr.ProcessingInstruction do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  defstruct name: nil
+
+  def eval(_expr, _node, _document, _context) do
+    false # currently not supported because html5ever will parse as comments
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/step.ex
+++ b/lib/meeseeks/selector/xpath/expr/step.ex
@@ -1,0 +1,27 @@
+defmodule Meeseeks.Selector.XPath.Expr.Step do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  alias Meeseeks.Selector
+  alias Meeseeks.Selector.XPath.Expr
+
+  defstruct combinator: nil, predicates: []
+
+  def eval(expr, node, document, context) do
+    case Selector.Combinator.next(expr.combinator, node, document) do
+      nil -> []
+      nodes when is_list(nodes) ->
+        filter_nodes(nodes, expr.predicates, document, context)
+      node -> filter_nodes([node], expr.predicates, document, context)
+    end
+  end
+
+  defp filter_nodes(nodes, predicates, document, context) do
+    Enum.filter(nodes, &filter_node(&1, predicates, document, context))
+  end
+
+  defp filter_node(node, predicates, document, context) do
+    Enum.all?(predicates, &Expr.eval(&1, node, document, context))
+  end
+end

--- a/lib/meeseeks/selector/xpath/expr/union.ex
+++ b/lib/meeseeks/selector/xpath/expr/union.ex
@@ -1,0 +1,26 @@
+defmodule Meeseeks.Selector.XPath.Expr.Union do
+  @moduledoc false
+
+  use Meeseeks.Selector.XPath.Expr
+
+  alias Meeseeks.Selector.XPath.Expr
+
+  defstruct e1: nil, e2: nil
+
+  def eval(expr, node, document, context) do
+    v1 = Expr.eval(expr.e1, node, document, context)
+    v2 = Expr.eval(expr.e2, node, document, context)
+    if Expr.Helpers.nodes?(v1) and Expr.Helpers.nodes?(v2) do
+      ns1 = MapSet.new(v1)
+      ns2 = MapSet.new(v2)
+      MapSet.union(ns1, ns2)
+      |> MapSet.to_list()
+      |> Enum.sort(&(comparable(&1) <= comparable(&2)))
+    else
+      raise "Invalid evaluated arguments to XPath union: #{inspect([v1, v2])}"
+    end
+  end
+
+  defp comparable(%{id: id}), do: id
+  defp comparable(x), do: x
+end

--- a/lib/meeseeks/selector/xpath/parser.ex
+++ b/lib/meeseeks/selector/xpath/parser.ex
@@ -1,0 +1,10 @@
+defmodule Meeseeks.Selector.XPath.Parser do
+  @moduledoc false
+
+  def parse_expression(tokens) do
+    case :xpath_expression_parser.parse(tokens) do
+      {:ok, expression} -> expression
+      error -> error
+    end
+  end
+end

--- a/lib/meeseeks/selector/xpath/predicate.ex
+++ b/lib/meeseeks/selector/xpath/predicate.ex
@@ -1,0 +1,15 @@
+defmodule Meeseeks.Selector.XPath.Predicate do
+  @moduledoc false
+
+  use Meeseeks.Selector
+
+  alias Meeseeks.Selector.XPath.Expr
+
+  defstruct e: nil
+
+  def match(selector, node, document, context) do
+    Expr.Helpers.boolean(Expr.eval(selector.e, node, document, context), document)
+  end
+
+  def filters(_), do: []
+end

--- a/lib/meeseeks/selector/xpath/tokenizer.ex
+++ b/lib/meeseeks/selector/xpath/tokenizer.ex
@@ -1,0 +1,8 @@
+defmodule Meeseeks.Selector.XPath.Tokenizer do
+  @moduledoc false
+
+  def tokenize(selector) do
+    selector_chars = selector |> String.strip |> String.to_char_list
+    :xmerl_xpath_scan.tokens(selector_chars)
+  end
+end

--- a/lib/meeseeks/selector/xpath/transpiler.ex
+++ b/lib/meeseeks/selector/xpath/transpiler.ex
@@ -1,0 +1,132 @@
+defmodule Meeseeks.Selector.XPath.Transpiler do
+  @moduledoc false
+
+  alias Meeseeks.Selector
+  alias Meeseeks.Selector.{Combinator, XPath}
+
+  # to_selectors
+
+  def to_selectors(%XPath.Expr.Filter{}) do
+    raise "XPath filter expressions are not supported outside of predicates"
+  end
+
+  def to_selectors(%XPath.Expr.Union{e1: e1, e2: e2}) do
+    List.flatten([to_selectors(e1), to_selectors(e2)])
+  end
+
+  def to_selectors(%XPath.Expr.Path{type: :abs, steps: steps}) do
+    case combine_steps(Enum.reverse(steps)) do
+      %Combinator.Self{selector: %{combinator: c, selectors: s}} ->
+        %Selector.Root{combinator: c, selectors: s}
+      %Combinator.DescendantsOrSelf{
+        selector: %Selector.Element{
+          combinator: %Combinator.Children{} = c,
+          selectors: [],
+          filters: nil}} -> %Selector.Element{combinator: c}
+      c -> %Selector.Root{combinator: c}
+    end
+  end
+
+  def to_selectors(%XPath.Expr.Path{type: :rel, steps: steps}) do
+    case combine_steps(Enum.reverse(steps)) do
+      %Combinator.Self{selector: selector} -> selector
+      %Combinator.Children{} = c -> %Selector.Element{combinator: c}
+      %Combinator.Descendants{} = c -> %Selector.Element{combinator: c}
+      c -> %Selector.Node{combinator: c}
+    end
+  end
+
+  # combine_steps
+
+  defp combine_steps(steps) do
+    Enum.reduce(steps, nil, fn(step, combinator) ->
+      selector = combine_predicates(step.predicates, combinator)
+      %{step.combinator | selector: selector}
+    end)
+  end
+
+  # combine_predicates
+
+  defp combine_predicates([selector_expr|filter_exprs], combinator) do
+    filters = case Enum.map(filter_exprs, &predicate/1) do
+                [] -> nil
+                filters -> filters
+              end
+    selector(selector_expr, combinator, filters)
+  end
+
+  # selector
+
+  defp selector(%XPath.Expr.NameTest{} = expr, combinator, filters) do
+    %Selector.Element{
+      selectors: name_test_selectors(expr),
+      combinator: combinator,
+      filters: filters}
+  end
+
+  defp selector(expr, %Combinator.Children{} = combinator, filters) do
+    %Selector.Element{
+      selectors: selectors_from_expr(expr),
+      combinator: combinator,
+      filters: filters}
+  end
+
+  defp selector(expr, %Combinator.Descendants{} = combinator, filters) do
+    %Selector.Element{
+      selectors: selectors_from_expr(expr),
+      combinator: combinator,
+      filters: filters}
+  end
+
+  defp selector(expr, combinator, filters) do
+    %Selector.Node{
+      selectors: selectors_from_expr(expr),
+      combinator: combinator,
+      filters: filters}
+  end
+
+  # selectors_from_expr
+
+  defp selectors_from_expr(%XPath.Expr.NameTest{} = expr) do
+    name_test_selectors(expr)
+  end
+
+  defp selectors_from_expr(%XPath.Expr.NodeType{} = expr) do
+    node_type_selectors(expr)
+  end
+
+  defp selectors_from_expr(expr) do
+    [predicate(expr)]
+  end
+
+  # name_test_selectors
+
+  defp name_test_selectors(%XPath.Expr.NameTest{namespace: ns, tag: nil}) do
+    [%Selector.Element.Namespace{value: ns}]
+  end
+
+  defp name_test_selectors(%XPath.Expr.NameTest{namespace: nil, tag: tag}) do
+    [%Selector.Element.Tag{value: tag}]
+  end
+
+  defp name_test_selectors(%XPath.Expr.NameTest{namespace: ns, tag: tag}) do
+    [%Selector.Element.Namespace{value: ns},
+     %Selector.Element.Tag{value: tag}]
+  end
+
+  # node_type_selectors
+
+  defp node_type_selectors(%XPath.Expr.NodeType{type: :node}) do
+    []
+  end
+
+  defp node_type_selectors(expr) do
+    [predicate(expr)]
+  end
+
+  # predicate
+
+  defp predicate(expr) do
+    %XPath.Predicate{e: expr}
+  end
+end

--- a/lib/meeseeks/xpath.ex
+++ b/lib/meeseeks/xpath.ex
@@ -1,0 +1,115 @@
+defmodule Meeseeks.XPath do
+  @moduledoc """
+  Compile XPath 1.0 selector syntax into `Meeseeks.Selector`s.
+
+  ## Supported Syntax
+
+  Supports almost all XPath 1.0 syntax with a few notable exceptions.
+
+  ### No top-level filter expressions
+
+  Due to the way Meeseeks selection works, top-level filter expressions like
+  `xpath("(//ol|//ul)[2]")`, which would select the second list element in the
+  document, are particularly difficult to implement. An error will be raised
+  if you try to use the above or any other top-level filter expression.
+
+  To do the above try something like:
+
+  ```elixir
+  Meeseeks.all(doc, xpath("ol|ul")) |> Enum.at(1)
+  ```
+
+  All other filter expressions, like `xpath("//div[2]")`, are valid.
+
+  ### No support for variable references
+
+  Variable references are not currently supported, meaning expression like
+  `xpath("*[position()=$p]")` are invalid and will raise an error.
+
+  To do the above try something like:
+
+  ```elixir
+  p = 2
+  xpath("*[position()=" <> Integer.to_string(p) <> "]")
+  ```
+
+  ### No support for id(), lang(), or translate() functions
+
+  These three functions from the core functions library are not currently
+  supported. A runtime error will be raised should they attempt to be used.
+
+  ### Namespace prefixes are not resolved to namespace uris
+
+  If you want to find a namespace, search for the namespace prefix of node,
+  not the expanded namespace-uri. `xpath("*[namespace-uri()='example']")`,
+  not `xpath("*[namespace-uri()='https://example.com/ns']")`
+
+  ### Selecting processing instructions is not supported
+
+  Because html5ever (and HTML5 in general) parses processing instructions as
+  comments, selecting processing instructions is not supported.
+
+  If you need to access information from processing instructions, look for
+  it in comment nodes.
+
+  ## Examples
+
+      iex> import Meeseeks.XPath
+      iex> xpath("//li[last()]")
+      %Meeseeks.Selector.Element{
+        combinator: %Meeseeks.Selector.Combinator.Children{
+          selector: %Meeseeks.Selector.Element{
+            combinator: nil,
+            filters: [
+              %Meeseeks.Selector.XPath.Predicate{e:
+                %Meeseeks.Selector.XPath.Expr.Predicate{
+                  e: %Meeseeks.Selector.XPath.Expr.Function{
+                    args: [],
+                    f: :last}}}],
+            selectors: [%Meeseeks.Selector.Element.Tag{value: "li"}]}},
+        filters: nil,
+        selectors: []}
+      iex> xpath("//ol|//ul")
+      [%Meeseeks.Selector.Element{
+         combinator: %Meeseeks.Selector.Combinator.Children{
+           selector: %Meeseeks.Selector.Element{
+             combinator: nil,
+             filters: nil,
+             selectors: [%Meeseeks.Selector.Element.Tag{value: "ol"}]}},
+         filters: nil,
+         selectors: []},
+       %Meeseeks.Selector.Element{
+          combinator: %Meeseeks.Selector.Combinator.Children{
+            selector: %Meeseeks.Selector.Element{
+              combinator: nil,
+              filters: nil,
+              selectors: [%Meeseeks.Selector.Element.Tag{value: "ul"}]}},
+          filters: nil,
+          selectors: []}]
+
+  """
+  alias Meeseeks.Selector.XPath
+
+  @doc """
+  Compiles a string representing XPath selector syntax into one or more
+  `Meeseeks.Selector`s.
+
+  When the string is static this work will be done during Elixir's
+  compilation, but if the string interpolates values the work will
+  occur at runtime.
+  """
+
+  defmacro xpath(string) when is_binary(string) do
+    string
+    |> XPath.compile_selectors()
+    |> Macro.escape()
+  end
+
+  defmacro xpath({:<<>>, _meta, _pieces} = interpolated_string) do
+    quote do: XPath.compile_selectors(unquote(interpolated_string))
+  end
+
+  defmacro xpath({:<>, _meta, _pieces} = interpolated_string) do
+    quote do: XPath.compile_selectors(unquote(interpolated_string))
+  end
+end

--- a/src/xpath_expression_parser.yrl
+++ b/src/xpath_expression_parser.yrl
@@ -1,0 +1,526 @@
+%%
+%% DERIVATIVE WORK COPYRIGHT ------------------------------------------------
+%%
+%% The MIT License (MIT)
+%%
+%% Copyright (c) 2017 Mischov (https://github.com/mischov)
+%%
+%% Permission is hereby granted, free of charge, to any person obtaining a
+%% copy of this software and associated documentation files (the "Software"),
+%% to deal in the Software without restriction, including without limitation
+%% the rights to use, copy, modify, merge, publish, distribute, sublicense,
+%% and/or sell copies of the Software, and to permit persons to whom the
+%% Software is furnished to do so, subject to the following conditions:
+%%
+%% The above copyright notice and this permission notice shall be included in
+%% all copies or substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+%% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+%% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+%% THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+%% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+%% FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+%% DEALINGS IN THE SOFTWARE.
+%%
+%% ORIGINAL COPYRIGHT -------------------------------------------------------
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2003-2016. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%% Description  : Yecc spec for XPATH grammar
+%%    This version of the parser is based on the XPATH spec:
+%%    http://www.w3.org/TR/1999/REC-xpath-19991116 (XPATH version 1.0)
+
+Nonterminals
+	'LocationPath'
+	'AbsoluteLocationPath'
+	'RelativeLocationPath'
+	'Step'
+%%	'AxisSpecifier'
+	'NodeTest'
+	'Predicate'
+	'PredicateExpr'
+	'AbbreviatedAbsoluteLocationPath'
+	'AbbreviatedRelativeLocationPath'
+	'AbbreviatedStep'
+%%	'AbbreviatedAxisSpecifier'
+	'Expr'
+	'PrimaryExpr'
+	'FunctionCall'
+	'Argument'
+	'UnionExpr'
+	'PathExpr'
+	'FilterExpr'
+	'OrExpr'
+	'AndExpr'
+	'EqualityExpr'
+	'RelationalExpr'
+	'AdditiveExpr'
+	'MultiplicativeExpr'
+	'UnaryExpr'
+%%	'Operator'
+%%	'OperatorName'
+	'MultiplyOperator'
+	'NameTest'
+	'<PredicateList>'
+	'<PredicateMember>'
+	'<ArgumentList>'
+	'<ArgumentMember>'
+	.
+
+Terminals
+	'number'
+	'axis'
+	'node_type'
+	'literal'
+	'prefix_test'
+	'var_reference'
+	'function_name'
+	'name'
+	'processing-instruction'
+	'wildcard'
+	'(' ')' '[' ']' '.' '..' '@' ',' '::'
+	'and' 'or' 'mod' 'div'
+	'/' '//' '|' '+' '-' '=' '!=' '<' '<=' '>' '>='
+	'*'
+	.
+
+Rootsymbol 'Expr'.
+
+Endsymbol '$end' .
+
+Left 100 'or' .
+Left 200 'and' .
+Left 300 '=' .
+Left 300 '!=' .
+Left 400 '<' .
+Left 400 '>=' .
+Left 400 '>' .
+Left 400 '<=' .
+Unary 500 '-' .
+
+Expect 2.
+
+%%------------------------------------------------------------
+%% Clauses
+%%
+
+%% [1]
+'LocationPath' -> 'RelativeLocationPath' :
+        path(rel, lists:flatten(['$1'])) .
+'LocationPath' -> 'AbsoluteLocationPath' :
+        path(abs, lists:flatten(['$1'])) .
+
+%% [2]
+'AbsoluteLocationPath' -> '/' 'RelativeLocationPath' : '$2' .
+'AbsoluteLocationPath' -> '/' :
+        erlang:error("Path `/` would return Document, did you mean `/*`?") .
+
+%% [3]
+'RelativeLocationPath' -> 'AbbreviatedAbsoluteLocationPath' : '$1' .
+'RelativeLocationPath' -> 'Step' : '$1' .
+'RelativeLocationPath' -> 'RelativeLocationPath' '/' 'Step' :
+	['$1', '$3'] .
+'RelativeLocationPath' -> 'AbbreviatedRelativeLocationPath' : '$1' .
+
+%% [4]
+'Step' -> 'axis' '::' 'NodeTest' '<PredicateList>'
+	: step(value('$1'), '$3', '$4') .
+'Step' -> 'axis' '::' 'NodeTest'
+	: step(value('$1'), '$3', []) .
+'Step' -> '@' 'name' '<PredicateList>'
+	: step(value('$1'), '$2', '$3') .
+'Step' -> '@' 'name'
+	: step('attribute', '$2', []) .
+'Step' -> 'NodeTest' '<PredicateList>'
+	: step('child', '$1', '$2') .
+'Step' -> 'NodeTest'
+	: step('child', '$1', []) .
+'Step' -> 'AbbreviatedStep' : unreachable("'Step' -> 'AbbreviatedStep'") .
+
+'<PredicateList>' -> '<PredicateMember>' : lists:reverse('$1') .
+
+'<PredicateMember>' -> '<PredicateMember>' 'Predicate'
+	: ['$2'|'$1'] .
+'<PredicateMember>' -> 'Predicate' : ['$1'] .
+
+%% [5]
+%% 'AxisSpecifier' -> 'axis' '::' : '$1' .
+%% 'AxisSpecifier' -> 'AbbreviatedAxisSpecifier' : '$1' .
+
+%% [7]
+'NodeTest' -> 'NameTest' : '$1' .
+'NodeTest' -> 'node_type' '(' ')' : node_type('$1') .
+'NodeTest' -> 'processing-instruction' '(' ')' : node_type('$1') .
+'NodeTest' -> 'processing-instruction' '(' 'literal' ')'
+	: processing_instruction('$3') .
+
+%% [8]
+'Predicate' -> '[' 'PredicateExpr' ']' : predicate_expr('$2') .
+
+%% [9]
+'PredicateExpr' -> 'Expr' : '$1' .
+
+%% [10]
+'AbbreviatedAbsoluteLocationPath'  -> '//' 'RelativeLocationPath'
+	: {'//', '$2'} .
+
+%% [11]
+'AbbreviatedRelativeLocationPath' -> 'RelativeLocationPath' '//' 'Step'
+	: {'$1', '//', '$3'} .
+
+%% [12]
+'AbbreviatedStep' -> '.' : unreachable("'AbbreviatedStep' -> '.'") .
+'AbbreviatedStep' -> '..' : unreachable("'AbbreviatedStep' -> '..'") .
+
+%% [13]
+%% 'AbbreviatedAxisSpecifier' ->  '$empty' : 'child' .
+%% 'AbbreviatedAxisSpecifier' ->  '@' : '$1' .
+
+%% [14]
+'Expr' -> 'OrExpr' : '$1' .
+
+%% [15]
+'PrimaryExpr' -> 'var_reference' : no_varrefs() .
+'PrimaryExpr' -> '(' Expr ')' : '$2' .
+'PrimaryExpr' -> 'literal' : literal_expr('$1') .
+'PrimaryExpr' -> 'number' : number_expr('$1') .
+'PrimaryExpr' -> 'FunctionCall' : '$1' .
+
+%% [16]
+'FunctionCall' -> 'function_name' '(' ')' : function_expr('$1', []) .
+'FunctionCall' -> 'function_name' '(' '<ArgumentList>' ')'
+	: function_expr('$1', '$3') .
+
+'<ArgumentList>' -> '<ArgumentMember>' : lists:reverse('$1') .
+
+'<ArgumentMember>' -> '<ArgumentMember>' ',' 'Argument'
+	: ['$3'|'$1'] .
+'<ArgumentMember>' -> 'Argument' : ['$1'] .
+
+%% [17]
+'Argument' -> 'Expr' : '$1' .
+
+%% [18]
+'UnionExpr' -> 'PathExpr' : '$1' .
+'UnionExpr' -> 'UnionExpr' '|' 'PathExpr' : union_expr('$1', '$3') .
+
+%% [19]
+'PathExpr' -> 'LocationPath' : '$1' .
+'PathExpr' -> 'FilterExpr' : '$1' .
+'PathExpr' -> 'FilterExpr' '/' 'RelativeLocationPath' :
+        ['$1', '$3'] .
+'PathExpr' -> 'FilterExpr' '//' 'RelativeLocationPath' :
+        unreachable("'PathExpr' -> 'FilterExpr' '//' 'RelativeLocationPath'") .
+
+%% [20]
+'FilterExpr' -> 'PrimaryExpr' : '$1' .
+'FilterExpr' -> 'FilterExpr' 'Predicate' : filter_expr('$1', '$2') .
+
+%% [21]
+'OrExpr' -> 'AndExpr' : '$1' .
+'OrExpr' -> 'OrExpr' 'or' 'AndExpr'
+	: boolean_expr('or', '$1', '$3') .
+
+%% [22]
+'AndExpr' -> 'EqualityExpr' : '$1' .
+'AndExpr' -> 'AndExpr' 'and' 'EqualityExpr'
+	: boolean_expr('and', '$1', '$3') .
+
+%% [23]
+'EqualityExpr' -> 'RelationalExpr' : '$1' .
+'EqualityExpr' -> 'EqualityExpr' '=' 'RelationalExpr'
+	: comparative_expr('=', '$1', '$3') .
+'EqualityExpr' -> 'EqualityExpr' '!=' 'RelationalExpr'
+	: comparative_expr('!=', '$1', '$3') .
+
+%%[24]
+'RelationalExpr' -> 'AdditiveExpr' : '$1' .
+'RelationalExpr' -> 'RelationalExpr' '<' 'AdditiveExpr'
+	: comparative_expr('<', '$1', '$3') .
+'RelationalExpr' -> 'RelationalExpr' '>' 'AdditiveExpr'
+	: comparative_expr('>', '$1', '$3') .
+'RelationalExpr' -> 'RelationalExpr' '<=' 'AdditiveExpr'
+	: comparative_expr('<=', '$1', '$3') .
+'RelationalExpr' -> 'RelationalExpr' '>=' 'AdditiveExpr'
+	: comparative_expr('>=', '$1', '$3') .
+
+%% [25]
+'AdditiveExpr' -> 'MultiplicativeExpr' : '$1' .
+'AdditiveExpr' -> 'AdditiveExpr' '+' 'MultiplicativeExpr'
+	: arithmetic_expr('+', '$1', '$3') .
+'AdditiveExpr' -> 'AdditiveExpr' '-' 'MultiplicativeExpr'
+	: arithmetic_expr('-', '$1', '$3') .
+
+%% [26]
+'MultiplicativeExpr' -> 'UnaryExpr' : '$1' .
+'MultiplicativeExpr' -> 'MultiplicativeExpr' 'MultiplyOperator' 'UnaryExpr'
+	: arithmetic_expr('*', '$1', '$3') .
+'MultiplicativeExpr' -> 'MultiplicativeExpr' 'div' 'UnaryExpr'
+	: arithmetic_expr('div', '$1', '$3') .
+'MultiplicativeExpr' -> 'MultiplicativeExpr' 'mod' 'UnaryExpr'
+	: arithmetic_expr('mod', '$1', '$3') .
+
+%% [27]
+'UnaryExpr' -> 'UnionExpr' : '$1' .
+'UnaryExpr' -> '-' UnaryExpr : negative_expr('$2') .
+
+%% [32]
+%% 'Operator' -> 'OperatorName' : '$1' .
+%% 'Operator' -> 'MultiplyOperator' : '$1' .
+%% 'Operator' -> '/' : '$1' .
+%% 'Operator' -> '//' : '$1' .
+%% 'Operator' -> '|' : '$1' .
+%% 'Operator' -> '+' : '$1' .
+%% 'Operator' -> '-' : '$1' .
+%% 'Operator' -> '=' : '$1' .
+%% 'Operator' -> '!=' : '$1' .
+%% 'Operator' -> '<' : '$1' .
+%% 'Operator' -> '<=' : '$1' .
+%% 'Operator' -> '>' : '$1' .
+%% 'Operator' -> '>=' : '$1' .
+
+%% [33]
+%% 'OperatorName' -> 'and' : '$1' .
+%% 'OperatorName' -> 'mod' : '$1' .
+%% 'OperatorName' -> 'div' : '$1' .
+
+%% [34]
+'MultiplyOperator' -> '*' : '*' .
+
+%% [37]
+'NameTest' -> 'wildcard' : '$1' .
+'NameTest' -> 'prefix_test' : '$1' .
+'NameTest' -> 'name' : '$1' .
+
+Erlang code.
+
+value({Token, _Line}) ->
+	Token;
+value({_Token, _Line, Value}) ->
+	Value.
+
+unreachable(Hint) ->
+        erlang:error("Reached unreachable: " ++ Hint).
+
+no_varrefs() ->
+        erlang:error("Variable references are not currently supported").
+
+%% path
+path(abs, [Step|Steps]) ->
+        case Step of
+          #{combinator := #{'__struct__' := 'Elixir.Meeseeks.Selector.Combinator.Children'}} ->
+            FirstStep = maps:update(combinator, step_combinator('self'), Step),
+            #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Path',
+              type => abs,
+              steps => [FirstStep|Steps]};
+          _ ->
+            #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Path',
+              type => abs,
+              steps => [Step|Steps]}
+        end;
+path(rel, Steps) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Path',
+          type => rel,
+          steps => Steps}.
+
+%% step
+step('attribute', Name, Predicates) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Step',
+          combinator => step_combinator('attribute'),
+          predicates =>  [attribute_name_test(Name) | Predicates]};
+step('following', Name, Predicates) ->
+        {'following', Name, Predicates};
+step('namespace', Name, Predicates) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Step',
+          combinator => step_combinator('namespace'),
+          predicates => [namespace_name_test(Name) | Predicates]};
+step('preceding', Name, Predicates) ->
+        {'preceding', Name, Predicates};
+step(Type, Name, Predicates) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Step',
+          combinator => step_combinator(Type),
+          predicates =>  [name_test(Name) | Predicates]}.
+
+%% step_combinator
+step_combinator(Type) ->
+        step_combinator(Type, nil).
+step_combinator('ancestor', Selector) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.Combinator.Ancestors',
+          selector => Selector};
+step_combinator('ancestor_or_self', Selector) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.Combinator.AncestorsOrSelf',
+          selector => Selector};
+step_combinator('attribute', Selector) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Combinator.Attributes',
+          selector => Selector};
+step_combinator('child', Selector) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.Combinator.Children',
+          selector => Selector};
+step_combinator('descendant', Selector) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.Combinator.Descendants',
+          selector => Selector};
+step_combinator('descendant_or_self', Selector) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.Combinator.DescendantsOrSelf',
+          selector => Selector};
+step_combinator('following', Selector) ->
+        {'following', Selector};
+step_combinator('following_sibling', Selector) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.Combinator.NextSiblings',
+          selector => Selector};
+step_combinator('namespace', Selector) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Combinator.Namespaces',
+          selector => Selector};
+step_combinator('parent', Selector) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.Combinator.Parent',
+          selector => Selector};
+step_combinator('preceding', Selector) ->
+        {'preceding', Selector};
+step_combinator('preceding_sibling', Selector) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.Combinator.PreviousSiblings',
+          selector => Selector};
+step_combinator('self', Selector) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.Combinator.Self',
+          selector => Selector}.
+
+%% node_type
+node_type({_Token, _Line, Type}) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NodeType',
+          type => Type}.
+
+%% processing_instruction
+processing_instruction({_Token, _Line, Name}) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.ProcessingInstruction',
+          name => Name}.
+
+%% union_expr
+union_expr(E1, E2) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Union',
+          e1 => E1,
+          e2 => E2}.
+
+%% filter_expr
+filter_expr(E, Predicate) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Filter',
+          e => E,
+          predicate => Predicate}.
+
+%% predicate_expr
+predicate_expr(E) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Predicate',
+          e => E}.
+
+%% literal_expr
+literal_expr(X) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Literal',
+          value => list_to_binary(value(X))}.
+
+%% number_expr
+number_expr(X) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Number',
+          value => value(X)}.
+
+%% function_expr
+function_expr(F, Args) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Function',
+          f => value(F),
+          args => Args}.
+
+%% boolean_expr
+boolean_expr(Op, E1, E2) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Boolean',
+          op => Op,
+          e1 => E1,
+          e2 => E2}.
+
+%% comparative_expr
+comparative_expr(Op, E1, E2) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Comparative',
+          op => Op,
+          e1 => E1,
+          e2 => E2}.
+
+%% arithmetic_expr
+arithmetic_expr(Op, E1, E2) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Arithmetic',
+          op => Op,
+          e1 => E1,
+          e2 => E2}.
+
+%% negative_expr
+negative_expr(E) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Negative',
+          e => E}.
+
+%% name_test
+name_test({'wildcard', _Line, _Wildcard}) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NameTest',
+          namespace => nil,
+          tag => list_to_binary("*")};
+name_test({'prefix_test', _Line, Ns}) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NameTest',
+          namespace => list_to_binary(Ns),
+          tag => nil};
+name_test({'name', _Line, {_All, [], N}}) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NameTest',
+          namespace => nil,
+          tag => list_to_binary(N)};
+name_test({'name', _Line, {_All, Ns, N}}) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NameTest',
+          namespace => list_to_binary(Ns),
+          tag => list_to_binary(N)};
+name_test(Else) ->
+        Else.
+
+%% attribute_name_test
+attribute_name_test({'wildcard', _Line, _Wildcard}) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.AttributeNameTest',
+          namespace => nil,
+          name => list_to_binary("*")};
+attribute_name_test({'prefix_test', _Line, Ns}) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.AttributeNameTest',
+          namespace => list_to_binary(Ns),
+          name => nil};
+attribute_name_test({'name', _Line, {_All, [], N}}) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.AttributeNameTest',
+          namespace => nil,
+          name => list_to_binary(N)};
+attribute_name_test({'name', _Line, {_All, Ns, N}}) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.AttributeNameTest',
+          namespace => list_to_binary(Ns),
+          name => list_to_binary(N)}.
+
+%% namespace_name_test
+namespace_name_test({'wildcard', _Line, _Wildcard}) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NamespaceNameTest',
+          namespace => nil,
+          name => list_to_binary("*")};
+namespace_name_test({'prefix_test', _Line, Ns}) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NamespaceNameTest',
+          namespace => list_to_binary(Ns),
+          name => nil};
+namespace_name_test({'name', _Line, {_All, [], N}}) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NamespaceNameTest',
+          namespace => nil,
+          name => list_to_binary(N)};
+namespace_name_test({'name', _Line, {_All, Ns, N}}) ->
+        #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NamespaceNameTest',
+          namespace => list_to_binary(Ns),
+          name => list_to_binary(N)}.

--- a/test/meeseeks/document_test.exs
+++ b/test/meeseeks/document_test.exs
@@ -19,7 +19,23 @@ defmodule Meeseeks.DocumentTest do
     assert Document.element?(@document, 1)
   end
 
-  test "body > div children" do
+  test "parent" do
+    assert Document.parent(@document, 7) == 4
+  end
+
+  test "no parent" do
+    assert Document.parent(@document, 1) == nil
+  end
+
+  test "ancestors" do
+    assert Document.ancestors(@document, 7) == [4, 3, 1]
+  end
+
+  test "no ancestors" do
+    assert Document.ancestors(@document, 1) == []
+  end
+
+  test "children" do
     assert Document.children(@document, 4) == [5, 6, 7, 10]
   end
 
@@ -29,6 +45,10 @@ defmodule Meeseeks.DocumentTest do
 
   test "siblings" do
     assert Document.siblings(@document, 6) == [5, 6, 7, 10]
+  end
+
+  test "previous_siblings" do
+    assert Document.previous_siblings(@document, 7) == [5, 6]
   end
 
   test "next_siblings" do

--- a/test/meeseeks/select_test.exs
+++ b/test/meeseeks/select_test.exs
@@ -32,57 +32,57 @@ defmodule Meeseeks.SelectTest do
       %Result{id: 14, document: @document},
       %Result{id: 19, document: @document},
       %Result{id: 22, document: @document}]
-    assert Select.all(@document, selector) == expected
+    assert Select.all(@document, selector, %{}) == expected
   end
 
   test "select first paragraph" do
     selector = css("div.main > p")
     expected = %Result{id: 8, document: @document}
-    assert Select.one(@document, selector) == expected
+    assert Select.one(@document, selector, %{}) == expected
   end
 
   test "select all with class 'main'" do
     selector = css(".main")
     expected = [
       %Result{id: 6, document: @document}]
-    assert Select.all(@document, selector) == expected
+    assert Select.all(@document, selector, %{}) == expected
   end
 
   test "select first with id 'first-p'" do
     selector = css("#first-p")
     expected = %Result{id: 8, document: @document}
-    assert Select.one(@document, selector) == expected
+    assert Select.one(@document, selector, %{}) == expected
   end
 
   test "select all with data attributes" do
     selector = css("*[^data-]")
     expected = [
       %Result{id: 11, document: @document}]
-    assert Select.all(@document, selector) == expected
+    assert Select.all(@document, selector, %{}) == expected
   end
 
   test "select third paragraph" do
     selector = css("p:nth-child(3)")
     expected = %Result{id: 14, document: @document}
-    assert Select.one(@document, selector) == expected
+    assert Select.one(@document, selector, %{}) == expected
   end
 
   test "select second-of-type that does not have [data-id=second-p]" do
     selector = css("p:nth-of-type(2):not([data-id=second-p])")
     expected = %Result{id: 22, document: @document}
-    assert Select.one(@document, selector) == expected
+    assert Select.one(@document, selector, %{}) == expected
   end
 
   test "select all with class 'nonexistent' (no match)" do
     selector = css(".nonexistent")
     expected = []
-    assert Select.all(@document, selector) == expected
+    assert Select.all(@document, selector, %{}) == expected
   end
 
   test "select one with class 'nonexistent' (no match)" do
     selector = css("*|*.nonexistent")
     expected = nil
-    assert Select.one(@document, selector) == expected
+    assert Select.one(@document, selector, %{}) == expected
   end
 
   @result %Result{id: 17, document: @document}
@@ -92,13 +92,13 @@ defmodule Meeseeks.SelectTest do
     expected = [
       %Result{id: 19, document: @document},
       %Result{id: 22, document: @document}]
-    assert Select.all(@result, selector) == expected
+    assert Select.all(@result, selector, %{}) == expected
   end
 
   test "select next sibling p of first p from result" do
     selector = css("#first-p + p")
     expected = [%Result{id: 11, document: @document},]
-    assert Select.all(@document, selector) == expected
+    assert Select.all(@document, selector, %{}) == expected
   end
 
   test "select next siblings of first p from result" do
@@ -107,13 +107,13 @@ defmodule Meeseeks.SelectTest do
       %Result{id: 11, document: @document},
       %Result{id: 14, document: @document},
       %Result{id: 17, document: @document}]
-    assert Select.all(@document, selector) == expected
+    assert Select.all(@document, selector, %{}) == expected
   end
 
   test "select with string instead of selector" do
     selector = "#first-p ~ *"
     assert_raise RuntimeError, ~r/^Received string/, fn ->
-      Select.all(@document, selector)
+      Select.all(@document, selector, %{})
     end
   end
 end

--- a/test/meeseeks/selector/combinators_test.exs
+++ b/test/meeseeks/selector/combinators_test.exs
@@ -1,0 +1,109 @@
+defmodule Meeseeks.Selector.CombinatorsTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.Combinator
+
+  @document Meeseeks.Parser.parse(
+    {"html", [], [
+        {"head", [], []},
+        {"body", [], [
+            {"div", [], [
+                {"p", [], ["1"]},
+                {"p", [], ["2"]},
+                {"div", [], [
+                    {"p", [], ["3"]},
+                    {"p", [], ["4"]}]},
+                {"p", [], ["5"]}]}]}]})
+
+  test "parent" do
+    combinator = %Combinator.Parent{}
+    node = Document.get_node(@document, 5)
+    expected = Document.get_node(@document, 4)
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+
+  test "ancestors" do
+    combinator = %Combinator.Ancestors{}
+    node = Document.get_node(@document, 6)
+    expected = Document.get_nodes(@document, [5, 4, 3, 1])
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+
+  test "ancestors or self" do
+    combinator = %Combinator.AncestorsOrSelf{}
+    node = Document.get_node(@document, 6)
+    expected = Document.get_nodes(@document, [6, 5, 4, 3, 1])
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+
+  test "children" do
+    combinator = %Combinator.Children{}
+    node = Document.get_node(@document, 9)
+    expected = Document.get_nodes(@document, [10, 12])
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+
+  test "child elements" do
+    combinator = %Combinator.ChildElements{}
+    node = Document.get_node(@document, 9)
+    expected = Document.get_nodes(@document, [10, 12])
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+
+  test "descendants" do
+    combinator = %Combinator.Descendants{}
+    node = Document.get_node(@document, 9)
+    expected = Document.get_nodes(@document, [10, 11, 12, 13])
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+
+  test "descendants or self" do
+    combinator = %Combinator.DescendantsOrSelf{}
+    node = Document.get_node(@document, 9)
+    expected = Document.get_nodes(@document, [9, 10, 11, 12, 13])
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+
+  test "descendant elements" do
+    combinator = %Combinator.DescendantElements{}
+    node = Document.get_node(@document, 9)
+    expected = Document.get_nodes(@document, [10, 12])
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+
+  test "previous siblings" do
+    combinator = %Combinator.PreviousSiblings{}
+    node = Document.get_node(@document, 9)
+    expected = Document.get_nodes(@document, [5, 7])
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+
+  test "next siblings" do
+    combinator = %Combinator.NextSiblings{}
+    node = Document.get_node(@document, 7)
+    expected = Document.get_nodes(@document, [9, 14])
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+
+  test "next sibling element" do
+    combinator = %Combinator.NextSiblingElement{}
+    node = Document.get_node(@document, 7)
+    expected = Document.get_node(@document, 9)
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+
+  test "next sibling elements" do
+    combinator = %Combinator.NextSiblingElements{}
+    node = Document.get_node(@document, 7)
+    expected = Document.get_nodes(@document, [9, 14])
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+
+  test "self" do
+    combinator = %Combinator.Self{}
+    node = Document.get_node(@document, 7)
+    expected = Document.get_node(@document, 7)
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+end

--- a/test/meeseeks/selector/element/attributes_test.exs
+++ b/test/meeseeks/selector/element/attributes_test.exs
@@ -8,67 +8,67 @@ defmodule Meeseeks.Selector.Element.AttributesTest do
   test "attribute exists" do
     selector = %Attribute.Attribute{attribute: "id"}
     element = element_with_attributes([{"id", "unique"}])
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "attribute exists, multiple attributes" do
     selector = %Attribute.Attribute{attribute: "id"}
     element = element_with_attributes([{"random", "attribute"}, {"id", "unique"}])
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "attribute with prefix exists" do
     selector = %Attribute.AttributePrefix{attribute: "data-"}
     element = element_with_attributes([{"data-model", "[1, 2, 3]"}])
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "attribute has value" do
     selector = %Attribute.Value{attribute: "x", value: "y"}
     element = element_with_attributes([{"x", "y"}])
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "attribute has value, multiple attributes" do
     selector = %Attribute.Value{attribute: "x", value: "y"}
     element = element_with_attributes([{"a", "b"}, {"x", "y"}])
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "attribute has value that contains" do
     selector = %Attribute.ValueContains{attribute: "x", value: "bcd"}
     element = element_with_attributes([{"x", "abcde"}])
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "attribute is has value (value_dash version)" do
     selector = %Attribute.ValueDash{attribute: "lang", value: "en"}
     element = element_with_attributes([{"lang", "en"}])
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "attribute starts with value then dash" do
     selector = %Attribute.ValueDash{attribute: "lang", value: "en"}
     element = element_with_attributes([{"lang", "en-proper"}])
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "attribute has whitespace separated values including value" do
     selector = %Attribute.ValueIncludes{attribute: "x", value: "b"}
     element = element_with_attributes([{"x", "a b c"}])
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "attribute has value with prefix" do
     selector = %Attribute.ValuePrefix{attribute: "x", value: "ab"}
     element = element_with_attributes([{"x", "abcde"}])
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "attribute has value with suffix" do
     selector = %Attribute.ValueSuffix{attribute: "x", value: "de"}
     element = element_with_attributes([{"x", "abcde"}])
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   defp element_with_attributes(attributes) do

--- a/test/meeseeks/selector/element/pseudo_classes_test.exs
+++ b/test/meeseeks/selector/element/pseudo_classes_test.exs
@@ -21,37 +21,37 @@ defmodule Meeseeks.Selector.PseudoTest do
   test "first p is first-child" do
     selector = %PseudoClass.FirstChild{}
     element = Document.get_node(@test_document, 6)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "second p is not first-child" do
     selector = %PseudoClass.FirstChild{}
     element = Document.get_node(@test_document, 9)
-    refute Selector.match?(selector, element, @test_document)
+    refute Selector.match(selector, element, @test_document, %{})
   end
 
   test "first span is first-of-type" do
     selector = %PseudoClass.FirstOfType{}
     element = Document.get_node(@test_document, 15)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "first span is last-child" do
     selector = %PseudoClass.LastChild{}
     element = Document.get_node(@test_document, 15)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "third p is last-of-type" do
     selector = %PseudoClass.LastOfType{}
     element = Document.get_node(@test_document, 12)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "third p is not last-child" do
     selector = %PseudoClass.LastChild{}
     element = Document.get_node(@test_document, 12)
-    refute Selector.match?(selector, element, @test_document)
+    refute Selector.match(selector, element, @test_document, %{})
   end
 
   test "first span is not(p)" do
@@ -59,7 +59,7 @@ defmodule Meeseeks.Selector.PseudoTest do
       args: [
         [%Element{selectors: [%Element.Tag{value: "p"}]}]]}
     element = Document.get_node(@test_document, 15)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "first p is not not(p)" do
@@ -67,7 +67,7 @@ defmodule Meeseeks.Selector.PseudoTest do
       args: [
         [%Element{selectors: [%Element.Tag{value: "p"}]}]]}
     element = Document.get_node(@test_document, 6)
-    refute Selector.match?(selector, element, @test_document)
+    refute Selector.match(selector, element, @test_document, %{})
   end
 
   test "first p is not(p:nth-child(even))" do
@@ -75,7 +75,7 @@ defmodule Meeseeks.Selector.PseudoTest do
       args: [
         [%Element{selectors: [%PseudoClass.NthChild{args: ["even"]}]}]]}
     element = Document.get_node(@test_document, 6)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "third p is not(p:nth-child(1), p:nth-child(2))" do
@@ -84,138 +84,138 @@ defmodule Meeseeks.Selector.PseudoTest do
         [%Element{selectors: [%PseudoClass.NthChild{args: [1]}]},
          %Element{selectors: [%PseudoClass.NthChild{args: [2]}]}]]}
     element = Document.get_node(@test_document, 12)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "second p is nth-child(even)" do
     selector = %PseudoClass.NthChild{args: ["even"]}
     element = Document.get_node(@test_document, 9)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "third p is not nth-child(even)" do
     selector = %PseudoClass.NthChild{args: ["even"]}
     element = Document.get_node(@test_document, 12)
-    refute Selector.match?(selector, element, @test_document)
+    refute Selector.match(selector, element, @test_document, %{})
   end
 
   test "first p is nth-child(odd)" do
     selector = %PseudoClass.NthChild{args: ["odd"]}
     element = Document.get_node(@test_document, 6)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "second p is not nth-child(odd)" do
     selector = %PseudoClass.NthChild{args: ["odd"]}
     element = Document.get_node(@test_document, 9)
-    refute Selector.match?(selector, element, @test_document)
+    refute Selector.match(selector, element, @test_document, %{})
   end
 
   test "second p is nth-child(2)" do
     selector = %PseudoClass.NthChild{args: [2]}
     element = Document.get_node(@test_document, 9)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "third p is not nth-child(2)" do
     selector = %PseudoClass.NthChild{args: [2]}
     element = Document.get_node(@test_document, 12)
-    refute Selector.match?(selector, element, @test_document)
+    refute Selector.match(selector, element, @test_document, %{})
   end
 
   test "second p is nth-child(2n+0)" do
     selector = %PseudoClass.NthChild{args: [2, 0]}
     element = Document.get_node(@test_document, 9)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "third p is not nth-child(2n+0)" do
     selector = %PseudoClass.NthChild{args: [2, 0]}
     element = Document.get_node(@test_document, 12)
-    refute Selector.match?(selector, element, @test_document)
+    refute Selector.match(selector, element, @test_document, %{})
   end
 
   test "first p is nth-child(2n+1)" do
     selector = %PseudoClass.NthChild{args: [2, 1]}
     element = Document.get_node(@test_document, 6)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "second p is nth-child(0n+2)" do
     selector = %PseudoClass.NthChild{args: [0, 2]}
     element = Document.get_node(@test_document, 9)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "third p is nth-child(3n)" do
     selector = %PseudoClass.NthChild{args: [3, 0]}
     element = Document.get_node(@test_document, 12)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "third p is nth-child(-2n+3)" do
     selector = %PseudoClass.NthChild{args: [-2, 3]}
     element = Document.get_node(@test_document, 12)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "first p is nth-child(3n-2)" do
     selector = %PseudoClass.NthChild{args: [3, -2]}
     element = Document.get_node(@test_document, 6)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "first p is nth-last-child(even)" do
     selector = %PseudoClass.NthLastChild{args: ["even"]}
     element = Document.get_node(@test_document, 6)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "first span is nth-last-child(1)" do
     selector = %PseudoClass.NthLastChild{args: [1]}
     element = Document.get_node(@test_document, 15)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "second p is nth-last-child(3n+0)" do
     selector = %PseudoClass.NthLastChild{args: [3, 0]}
     element = Document.get_node(@test_document, 9)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "second p is nth-last-of-type(even)" do
     selector = %PseudoClass.NthLastOfType{args: ["even"]}
     element = Document.get_node(@test_document, 9)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "third p is nth-last-of-type(1)" do
     selector = %PseudoClass.NthLastOfType{args: [1]}
     element = Document.get_node(@test_document, 12)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "first p is nth-last-of-type(3n+0)" do
     selector = %PseudoClass.NthLastOfType{args: [3, 0]}
     element = Document.get_node(@test_document, 6)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "second p is nth-of-type(even)" do
     selector = %PseudoClass.NthOfType{args: ["even"]}
     element = Document.get_node(@test_document, 9)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "first p is nth-of-type(1)" do
     selector = %PseudoClass.NthOfType{args: [1]}
     element = Document.get_node(@test_document, 6)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 
   test "third p is nth-of-type(3n+0)" do
     selector = %PseudoClass.NthOfType{args: [3, 0]}
     element = Document.get_node(@test_document, 12)
-    assert Selector.match?(selector, element, @test_document)
+    assert Selector.match(selector, element, @test_document, %{})
   end
 end

--- a/test/meeseeks/selector/element_test.exs
+++ b/test/meeseeks/selector/element_test.exs
@@ -13,7 +13,7 @@ defmodule Meeseeks.Selector.ElementTest do
     selector = %Element{
       selectors: [
         %Element.Namespace{value: "namespaced"}]}
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "namespace and tag matches" do
@@ -25,7 +25,7 @@ defmodule Meeseeks.Selector.ElementTest do
       selectors: [
         %Element.Namespace{value: "namespaced"},
         %Element.Tag{value: "tag"}]}
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "tag matches namespaced tag" do
@@ -36,7 +36,7 @@ defmodule Meeseeks.Selector.ElementTest do
     selector = %Element{
       selectors: [
         %Element.Tag{value: "tag"}]}
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "tag matches unnamespaced tag" do
@@ -46,7 +46,7 @@ defmodule Meeseeks.Selector.ElementTest do
     selector = %Element{
       selectors: [
         %Element.Tag{value: "tag"}]}
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "tag doesn't match" do
@@ -56,7 +56,7 @@ defmodule Meeseeks.Selector.ElementTest do
     selector = %Element{
       selectors: [
         %Element.Tag{value: "tag"}]}
-    refute Selector.match?(selector, element, nil)
+    refute Selector.match(selector, element, nil, %{})
   end
 
   test "namespace, tag, id, and class matches" do
@@ -71,6 +71,6 @@ defmodule Meeseeks.Selector.ElementTest do
         %Element.Tag{value: "tag"},
         %Element.Attribute.Value{attribute: "id", value: "valid"},
         %Element.Attribute.ValueIncludes{attribute: "class", value: "match"}]}
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 end

--- a/test/meeseeks/selector/node_test.exs
+++ b/test/meeseeks/selector/node_test.exs
@@ -1,0 +1,72 @@
+defmodule Meeseeks.Selector.NodeTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector
+  alias Meeseeks.Selector.{Element, Node}
+
+  test "node matches comment" do
+    element = %Document.Comment{
+      id: 1,
+      content: "Root comment"}
+    selector = %Node{}
+    assert Selector.match?(selector, element, nil)
+  end
+
+  test "node matches data" do
+    element = %Document.Data{
+      parent: 1,
+      id: 2,
+      content: "Am script I guess?"}
+    selector = %Node{}
+    assert Selector.match?(selector, element, nil)
+  end
+
+  test "node matches doctype" do
+    element = %Document.Doctype{
+      id: 1}
+    selector = %Node{}
+    assert Selector.match?(selector, element, nil)
+  end
+
+  test "node matches element" do
+    element = %Document.Element{
+      parent: 1,
+      id: 2,
+      namespace: "random",
+      tag: "element"}
+    selector = %Node{}
+    assert Selector.match?(selector, element, nil)
+  end
+
+  test "node matches text" do
+    element = %Document.Text{
+      parent: 1,
+      id: 2,
+      content: "Hi"}
+    selector = %Node{}
+    assert Selector.match?(selector, element, nil)
+  end
+
+  test "element with selector match" do
+    element = %Document.Element{
+      id: 1,
+      namespace: "root",
+      tag: "element"}
+    selector = %Node{
+      selectors: [
+        %Element.Namespace{value: "root"}]}
+    assert Selector.match?(selector, element, nil)
+  end
+
+  test "element with selector doesn't match" do
+    element = %Document.Element{
+      id: 1,
+      namespace: "root",
+      tag: "element"}
+    selector = %Node{
+      selectors: [
+        %Element.Namespace{value: "not-root"}]}
+    refute Selector.match?(selector, element, nil)
+  end
+end

--- a/test/meeseeks/selector/node_test.exs
+++ b/test/meeseeks/selector/node_test.exs
@@ -10,7 +10,7 @@ defmodule Meeseeks.Selector.NodeTest do
       id: 1,
       content: "Root comment"}
     selector = %Node{}
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "node matches data" do
@@ -19,14 +19,14 @@ defmodule Meeseeks.Selector.NodeTest do
       id: 2,
       content: "Am script I guess?"}
     selector = %Node{}
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "node matches doctype" do
     element = %Document.Doctype{
       id: 1}
     selector = %Node{}
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "node matches element" do
@@ -36,7 +36,7 @@ defmodule Meeseeks.Selector.NodeTest do
       namespace: "random",
       tag: "element"}
     selector = %Node{}
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "node matches text" do
@@ -45,7 +45,7 @@ defmodule Meeseeks.Selector.NodeTest do
       id: 2,
       content: "Hi"}
     selector = %Node{}
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "element with selector match" do
@@ -56,7 +56,7 @@ defmodule Meeseeks.Selector.NodeTest do
     selector = %Node{
       selectors: [
         %Element.Namespace{value: "root"}]}
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "element with selector doesn't match" do
@@ -67,6 +67,6 @@ defmodule Meeseeks.Selector.NodeTest do
     selector = %Node{
       selectors: [
         %Element.Namespace{value: "not-root"}]}
-    refute Selector.match?(selector, element, nil)
+    refute Selector.match(selector, element, nil, %{})
   end
 end

--- a/test/meeseeks/selector/root_test.exs
+++ b/test/meeseeks/selector/root_test.exs
@@ -1,0 +1,58 @@
+defmodule Meeseeks.Selector.RootTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector
+  alias Meeseeks.Selector.{Element, Root}
+
+  test "root matches" do
+    element = %Document.Element{
+      id: 1,
+      namespace: "root",
+      tag: "element"}
+    selector = %Root{}
+    assert Selector.match?(selector, element, nil)
+  end
+
+  test "not root doesn't match" do
+    element = %Document.Element{
+      parent: 1,
+      id: 2,
+      tag: "tag"}
+    selector = %Root{}
+    refute Selector.match?(selector, element, nil)
+  end
+
+  test "root with selector matches" do
+    element = %Document.Element{
+      id: 1,
+      namespace: "root",
+      tag: "element"}
+    selector = %Root{
+      selectors: [
+        %Element.Namespace{value: "root"}]}
+    assert Selector.match?(selector, element, nil)
+  end
+
+  test "not root with selector doesn't match" do
+    element = %Document.Element{
+      parent: 1,
+      id: 2,
+      tag: "tag"}
+    selector = %Root{
+      selectors: [
+        %Element.Namespace{value: "root"}]}
+    refute Selector.match?(selector, element, nil)
+  end
+
+  test "root with selector doesn't match" do
+    element = %Document.Element{
+      id: 1,
+      namespace: "root",
+      tag: "element"}
+    selector = %Root{
+      selectors: [
+        %Element.Namespace{value: "not-root"}]}
+    refute Selector.match?(selector, element, nil)
+  end
+end

--- a/test/meeseeks/selector/root_test.exs
+++ b/test/meeseeks/selector/root_test.exs
@@ -11,7 +11,7 @@ defmodule Meeseeks.Selector.RootTest do
       namespace: "root",
       tag: "element"}
     selector = %Root{}
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "not root doesn't match" do
@@ -20,7 +20,7 @@ defmodule Meeseeks.Selector.RootTest do
       id: 2,
       tag: "tag"}
     selector = %Root{}
-    refute Selector.match?(selector, element, nil)
+    refute Selector.match(selector, element, nil, %{})
   end
 
   test "root with selector matches" do
@@ -31,7 +31,7 @@ defmodule Meeseeks.Selector.RootTest do
     selector = %Root{
       selectors: [
         %Element.Namespace{value: "root"}]}
-    assert Selector.match?(selector, element, nil)
+    assert Selector.match(selector, element, nil, %{})
   end
 
   test "not root with selector doesn't match" do
@@ -42,7 +42,7 @@ defmodule Meeseeks.Selector.RootTest do
     selector = %Root{
       selectors: [
         %Element.Namespace{value: "root"}]}
-    refute Selector.match?(selector, element, nil)
+    refute Selector.match(selector, element, nil, %{})
   end
 
   test "root with selector doesn't match" do
@@ -53,6 +53,6 @@ defmodule Meeseeks.Selector.RootTest do
     selector = %Root{
       selectors: [
         %Element.Namespace{value: "not-root"}]}
-    refute Selector.match?(selector, element, nil)
+    refute Selector.match(selector, element, nil, %{})
   end
 end

--- a/test/meeseeks/selector/xpath/combinators_test.exs
+++ b/test/meeseeks/selector/xpath/combinators_test.exs
@@ -1,0 +1,24 @@
+defmodule Meeseeks.Selector.XPath.CombinatorsTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.{Combinator, XPath}
+
+  @attributes [{"id", "unique"}, {"class", "a couple"}]
+  @document Meeseeks.Parser.parse(
+    {"awesome:div", @attributes, []})
+
+  test "attributes" do
+    combinator = %XPath.Combinator.Attributes{}
+    node = Document.get_node(@document, 1)
+    expected = @attributes
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+
+  test "namespaces" do
+    combinator = %XPath.Combinator.Namespaces{}
+    node = Document.get_node(@document, 1)
+    expected = "awesome"
+    assert Combinator.next(combinator, node, @document) == expected
+  end
+end

--- a/test/meeseeks/selector/xpath/expr/arithmetic_test.exs
+++ b/test/meeseeks/selector/xpath/expr/arithmetic_test.exs
@@ -1,0 +1,161 @@
+defmodule Meeseeks.Selector.XPath.Expr.ArithmeticTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.Combinator
+  alias Meeseeks.Selector.XPath.Expr
+
+  @document Meeseeks.parse(
+    {"book", [], [
+        {"chapter", [], [
+            {"page", [], ["1"]},
+            {"page", [], ["2"]}]}]})
+
+  test "add" do
+    expr = %Expr.Arithmetic{
+      op: :+,
+      e1: %Expr.Number{value: 2},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 4
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "infinity + 1" do
+    expr = %Expr.Arithmetic{
+      op: :+,
+      e1: %Expr.Number{value: :Infinity},
+      e2: %Expr.Number{value: 1}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = :Infinity
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "subtract" do
+    expr = %Expr.Arithmetic{
+      op: :-,
+      e1: %Expr.Number{value: 2},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 0
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "multiply" do
+    expr = %Expr.Arithmetic{
+      op: :*,
+      e1: %Expr.Number{value: 2},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 4
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "divide" do
+    expr = %Expr.Arithmetic{
+      op: :div,
+      e1: %Expr.Number{value: 2},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 1
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "divide by zero" do
+    expr = %Expr.Arithmetic{
+      op: :div,
+      e1: %Expr.Number{value: 2},
+      e2: %Expr.Number{value: 0}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = :Infinity
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "mod" do
+    expr = %Expr.Arithmetic{
+      op: :mod,
+      e1: %Expr.Number{value: 2},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 0
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "valid string" do
+    expr = %Expr.Arithmetic{
+      op: :+,
+      e1: %Expr.Literal{value: "2"},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 4
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "invalid string" do
+    expr = %Expr.Arithmetic{
+      op: :+,
+      e1: %Expr.Literal{value: "two"},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = :NaN
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "boolean" do
+    expr = %Expr.Arithmetic{
+      op: :+,
+      e1: %Expr.Function{f: :true, args: []},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 3
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "nodeset" do
+    expr = %Expr.Arithmetic{
+      op: :+,
+      e1: %Expr.Path{
+        steps: [
+          %Expr.Step{
+            combinator: %Combinator.DescendantsOrSelf{selector: nil},
+            predicates: [%Expr.NodeType{type: :node}]},
+          %Expr.Step{
+            combinator: %Combinator.Children{selector: nil},
+            predicates: [%Expr.NameTest{ namespace: nil, tag: "page"}]}],
+        type: :abs},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 3
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "nodeset empty" do
+    expr = %Expr.Arithmetic{
+      op: :+,
+      e1: %Expr.Path{
+        steps: [
+          %Expr.Step{
+            combinator: %Combinator.DescendantsOrSelf{selector: nil},
+            predicates: [%Expr.NodeType{type: :node}]},
+          %Expr.Step{
+            combinator: %Combinator.Children{selector: nil},
+            predicates: [%Expr.NameTest{ namespace: nil, tag: "missing"}]}],
+        type: :abs},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = :NaN
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+end

--- a/test/meeseeks/selector/xpath/expr/attribute_name_test_test.exs
+++ b/test/meeseeks/selector/xpath/expr/attribute_name_test_test.exs
@@ -1,0 +1,132 @@
+defmodule Meeseeks.Selector.XPath.Expr.AttributeNameTestTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.XPath.Expr
+
+  test "any attribute" do
+    expr = %Expr.AttributeNameTest{name: "*"}
+    node = {"any:attribute", nil}
+    document = nil
+    context = nil
+    expected = true
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "matching namespace any name" do
+    expr = %Expr.AttributeNameTest{namespace: "hello", name: "*"}
+    node = {"hello:world", nil}
+    document = nil
+    context = nil
+    expected = true
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "non-matching namespace any name" do
+    expr = %Expr.AttributeNameTest{namespace: "hello", name: "*"}
+    node = {"goodbye:world", nil}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "namespace any name without namespace" do
+    expr = %Expr.AttributeNameTest{namespace: "hello", name: "*"}
+    node = {"nope", nil}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "matching namespace no name" do
+    expr = %Expr.AttributeNameTest{namespace: "hello"}
+    node = {"hello:world", nil}
+    document = nil
+    context = nil
+    expected = true
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "non-matching namespace no name" do
+    expr = %Expr.AttributeNameTest{namespace: "hello"}
+    node = {"goodbye:world", nil}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "namespace no name without namespace" do
+    expr = %Expr.AttributeNameTest{namespace: "hello"}
+    node = {"nope", nil}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "matching name" do
+    expr = %Expr.AttributeNameTest{name: "world"}
+    node = {"hello:world", nil}
+    document = nil
+    context = nil
+    expected = true
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "non-matching name" do
+    expr = %Expr.AttributeNameTest{name: "world"}
+    node = {"goodmorning:vietnam", nil}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "matching namespace and name" do
+    expr = %Expr.AttributeNameTest{namespace: "hello", name: "world"}
+    node = {"hello:world", nil}
+    document = nil
+    context = nil
+    expected = true
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "matching namespace non-matching name" do
+    expr = %Expr.AttributeNameTest{namespace: "hello", name: "world"}
+    node = {"hello:goodbye", nil}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "non-matching namespace matching name" do
+    expr = %Expr.AttributeNameTest{namespace: "hello", name: "world"}
+    node = {"goodbye:world", nil}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "namespace and name without namespace" do
+    expr = %Expr.AttributeNameTest{namespace: "hello", name: "world"}
+    node = {"world", nil}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "non-attribute node doesn't match" do
+    expr = %Expr.AttributeNameTest{name: "world"}
+    node = %Document.Text{id: 1}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+end

--- a/test/meeseeks/selector/xpath/expr/boolean_test.exs
+++ b/test/meeseeks/selector/xpath/expr/boolean_test.exs
@@ -1,0 +1,183 @@
+defmodule Meeseeks.Selector.XPath.Expr.BooleanTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.Combinator
+  alias Meeseeks.Selector.XPath.Expr
+
+  @document Meeseeks.parse(
+    {"book", [], [
+        {"chapter", [], [
+            {"page", [], ["1"]},
+            {"page", [], ["2"]}]}]})
+
+  test "true or true" do
+    expr = %Expr.Boolean{
+      op: :or,
+      e1: %Expr.Function{f: :true, args: []},
+      e2: %Expr.Function{f: :true, args: []}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "false or true" do
+    expr = %Expr.Boolean{
+      op: :or,
+      e1: %Expr.Function{f: :false, args: []},
+      e2: %Expr.Function{f: :true, args: []}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "false or false" do
+    expr = %Expr.Boolean{
+      op: :or,
+      e1: %Expr.Function{f: :false, args: []},
+      e2: %Expr.Function{f: :false, args: []}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = false
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "true and true" do
+    expr = %Expr.Boolean{
+      op: :and,
+      e1: %Expr.Function{f: :true, args: []},
+      e2: %Expr.Function{f: :true, args: []}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "true and false" do
+    expr = %Expr.Boolean{
+      op: :and,
+      e1: %Expr.Function{f: :true, args: []},
+      e2: %Expr.Function{f: :false, args: []}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = false
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "false and true" do
+    expr = %Expr.Boolean{
+      op: :and,
+      e1: %Expr.Function{f: :false, args: []},
+      e2: %Expr.Function{f: :true, args: []}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = false
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "true string" do
+    expr = %Expr.Boolean{
+      op: :and,
+      e1: %Expr.Literal{value: "hello"},
+      e2: %Expr.Function{f: :true, args: []}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "false string" do
+    expr = %Expr.Boolean{
+      op: :and,
+      e1: %Expr.Literal{value: ""},
+      e2: %Expr.Function{f: :true, args: []}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = false
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "number true" do
+    expr = %Expr.Boolean{
+      op: :and,
+      e1: %Expr.Number{value: 2},
+      e2: %Expr.Function{f: :true, args: []}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "number false" do
+    expr = %Expr.Boolean{
+      op: :and,
+      e1: %Expr.Number{value: 0},
+      e2: %Expr.Function{f: :true, args: []}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = false
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "NaN" do
+    expr = %Expr.Boolean{
+      op: :and,
+      e1: %Expr.Number{value: :NaN},
+      e2: %Expr.Function{f: :true, args: []}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = false
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "Infinity" do
+    expr = %Expr.Boolean{
+      op: :and,
+      e1: %Expr.Number{value: :Infinity},
+      e2: %Expr.Function{f: :true, args: []}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "nodeset" do
+    expr = %Expr.Boolean{
+      op: :and,
+      e1: %Expr.Path{
+        steps: [
+          %Expr.Step{
+            combinator: %Combinator.DescendantsOrSelf{selector: nil},
+            predicates: [%Expr.NodeType{type: :node}]},
+          %Expr.Step{
+            combinator: %Combinator.Children{selector: nil},
+            predicates: [%Expr.NameTest{ namespace: nil, tag: "page"}]}],
+        type: :abs},
+      e2: %Expr.Function{f: :true, args: []}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "nodeset empty" do
+    expr = %Expr.Boolean{
+      op: :and,
+      e1: %Expr.Path{
+        steps: [
+          %Expr.Step{
+            combinator: %Combinator.DescendantsOrSelf{selector: nil},
+            predicates: [%Expr.NodeType{type: :node}]},
+          %Expr.Step{
+            combinator: %Combinator.Children{selector: nil},
+            predicates: [%Expr.NameTest{ namespace: nil, tag: "missing"}]}],
+        type: :abs},
+      e2: %Expr.Function{f: :true, args: []}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = false
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+end

--- a/test/meeseeks/selector/xpath/expr/comparative_test.exs
+++ b/test/meeseeks/selector/xpath/expr/comparative_test.exs
@@ -1,0 +1,221 @@
+defmodule Meeseeks.Selector.XPath.Expr.ComparativeTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.Combinator
+  alias Meeseeks.Selector.XPath.Expr
+
+  @document Meeseeks.parse(
+    {"book", [], [
+        {"chapter", [], [
+            {"page", [], ["1"]},
+            {"page", [], ["2"]}]}]})
+
+  test "equal" do
+    expr = %Expr.Comparative{
+      op: :=,
+      e1: %Expr.Number{value: 2},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "not equal" do
+    expr = %Expr.Comparative{
+      op: :!=,
+      e1: %Expr.Number{value: 1},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "less than or equal to" do
+    expr = %Expr.Comparative{
+      op: :<=,
+      e1: %Expr.Number{value: 1},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "less than" do
+    expr = %Expr.Comparative{
+      op: :<,
+      e1: %Expr.Number{value: 1},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "greater than or equal to" do
+    expr = %Expr.Comparative{
+      op: :>=,
+      e1: %Expr.Number{value: 2},
+      e2: %Expr.Number{value: 1}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "greater than" do
+    expr = %Expr.Comparative{
+      op: :>,
+      e1: %Expr.Number{value: 2},
+      e2: %Expr.Number{value: 1}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "greater than NaN" do
+    expr = %Expr.Comparative{
+      op: :>,
+      e1: %Expr.Number{value: 2},
+      e2: %Expr.Number{value: :NaN}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "less than Infinity" do
+    expr = %Expr.Comparative{
+      op: :<,
+      e1: %Expr.Number{value: 2},
+      e2: %Expr.Number{value: :Infinity}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "greater than -Infinity" do
+    expr = %Expr.Comparative{
+      op: :>,
+      e1: %Expr.Number{value: 2},
+      e2: %Expr.Number{value: :"-Infinity"}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "eq string" do
+    expr = %Expr.Comparative{
+      op: :=,
+      e1: %Expr.Literal{value: "2"},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "comp string" do
+    expr = %Expr.Comparative{
+      op: :<,
+      e1: %Expr.Literal{value: "1"},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "eq boolean" do
+    expr = %Expr.Comparative{
+      op: :=,
+      e1: %Expr.Function{f: :false, args: []},
+      e2: %Expr.Number{value: 0}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "comp boolean" do
+    expr = %Expr.Comparative{
+      op: :<,
+      e1: %Expr.Function{f: :true, args: []},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "eq nodeset" do
+    expr = %Expr.Comparative{
+      op: :=,
+      e1: %Expr.Path{
+        steps: [
+          %Expr.Step{
+            combinator: %Combinator.DescendantsOrSelf{selector: nil},
+            predicates: [%Expr.NodeType{type: :node}]},
+          %Expr.Step{
+            combinator: %Combinator.Children{selector: nil},
+            predicates: [%Expr.NameTest{ namespace: nil, tag: "page"}]}],
+        type: :abs},
+      e2: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "comp nodeset" do
+    expr = %Expr.Comparative{
+      op: :>,
+      e1: %Expr.Path{
+        steps: [
+          %Expr.Step{
+            combinator: %Combinator.DescendantsOrSelf{selector: nil},
+            predicates: [%Expr.NodeType{type: :node}]},
+          %Expr.Step{
+            combinator: %Combinator.Children{selector: nil},
+            predicates: [%Expr.NameTest{ namespace: nil, tag: "page"}]}],
+        type: :abs},
+      e2: %Expr.Number{value: 3}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = false
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "nodesets" do
+    expr = %Expr.Comparative{
+      op: :=,
+      e1: %Expr.Path{
+        steps: [
+          %Expr.Step{
+            combinator: %Combinator.DescendantsOrSelf{selector: nil},
+            predicates: [%Expr.NodeType{type: :node}]},
+          %Expr.Step{
+            combinator: %Combinator.Children{selector: nil},
+            predicates: [%Expr.NameTest{ namespace: nil, tag: "missing"}]}],
+        type: :abs},
+      e2: %Expr.Path{
+        steps: [
+          %Expr.Step{
+            combinator: %Combinator.DescendantsOrSelf{selector: nil},
+            predicates: [%Expr.NodeType{type: :node}]},
+          %Expr.Step{
+            combinator: %Combinator.Children{selector: nil},
+            predicates: [%Expr.NameTest{ namespace: nil, tag: "page"}]}],
+        type: :abs}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = false
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+end

--- a/test/meeseeks/selector/xpath/expr/function_test.exs
+++ b/test/meeseeks/selector/xpath/expr/function_test.exs
@@ -1,0 +1,603 @@
+defmodule Meeseeks.Selector.XPath.Expr.FunctionTest do
+  use ExUnit.Case
+
+  alias Meeseeks.{Context, Document}
+  alias Meeseeks.Selector.Combinator
+  alias Meeseeks.Selector.XPath.Expr
+
+  @nodes Context.nodes_key()
+  @document Meeseeks.Parser.parse(
+    {"html", [], [
+        {"head", [], []},
+        {"body", [], [
+            {"div", [], [
+                {"p", [], ["1"]},
+                {"special:p", [], ["2"]},
+                {"div", [], [
+                    {"p", [], ["3"]},
+                    {"p", [], ["4"]}]},
+                {"p", [], ["5"]}]}]}]})
+
+  # last
+
+  test "last no args" do
+    expr = %Expr.Function{
+      f: :last,
+      args: []}
+    node = Document.get_node(@document, 4)
+    context = %{@nodes => Document.get_nodes(@document)}
+    expected = 15
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # position
+
+  test "position no args" do
+    expr = %Expr.Function{
+      f: :position,
+      args: []}
+    node = Document.get_node(@document, 7)
+    context = %{@nodes => Document.get_nodes(@document)}
+    expected = 7
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # count
+
+  test "count no args" do
+    expr = %Expr.Function{
+      f: :count,
+      args: [
+        %Expr.Path{
+          steps: [
+            %Expr.Step{
+              combinator: %Combinator.DescendantsOrSelf{selector: nil},
+              predicates: [%Expr.NodeType{type: :node}]},
+            %Expr.Step{
+              combinator: %Combinator.Children{selector: nil},
+              predicates: [%Expr.NameTest{ namespace: nil, tag: "p"}]}],
+          type: :abs}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 5
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # local-name
+
+  test "local-name no args" do
+    expr = %Expr.Function{
+      f: :"local-name",
+      args: []}
+    node = Document.get_node(@document, 7)
+    context = %{}
+    expected = "p"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "local-name one arg" do
+    expr = %Expr.Function{
+      f: :"local-name",
+      args: [
+        %Expr.Path{
+          steps: [
+            %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                       predicates: [%Expr.NameTest{namespace: nil,
+                                                   tag: "p"}]}],
+          type: :rel}]}
+    node = Document.get_node(@document, 7)
+    context = %{}
+    expected = "p"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # namespace-uri
+
+  test "namespace-uri no args" do
+    expr = %Expr.Function{
+      f: :"namespace-uri",
+      args: []}
+    node = Document.get_node(@document, 7)
+    context = %{}
+    expected = "special"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "namespace-uri one arg" do
+    expr = %Expr.Function{
+      f: :"namespace-uri",
+      args: [
+        %Expr.Path{
+          steps: [
+            %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                       predicates: [%Expr.NameTest{namespace: nil,
+                                                   tag: "p"}]}],
+          type: :rel}]}
+    node = Document.get_node(@document, 5)
+    context = %{}
+    expected = ""
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # name
+
+  test "name no args" do
+    expr = %Expr.Function{
+      f: :name,
+      args: []}
+    node = Document.get_node(@document, 7)
+    context = %{}
+    expected = "special:p"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "name one arg" do
+    expr = %Expr.Function{
+      f: :name,
+      args: [
+        %Expr.Path{
+          steps: [
+            %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                       predicates: [%Expr.NameTest{namespace: nil,
+                                                   tag: "p"}]}],
+          type: :rel}]}
+    node = Document.get_node(@document, 5)
+    context = %{}
+    expected = "p"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # string
+
+  test "string no args" do
+    expr = %Expr.Function{
+      f: :string,
+      args: []}
+    node = Document.get_node(@document, 7)
+    context = %{}
+    expected = "2"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "string one arg" do
+    expr = %Expr.Function{
+      f: :string,
+      args: [%Expr.Number{value: :Infinity}]}
+    node = Document.get_node(@document, 7)
+    context = %{}
+    expected = "Infinity"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # concat
+
+  test "concat three args" do
+    expr = %Expr.Function{
+      f: :concat,
+      args: [
+        %Expr.Number{value: :Infinity},
+        %Expr.Literal{value: " plus "},
+        %Expr.Number{value: 1}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = "Infinity plus 1"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # starts-with
+
+  test "starts-with two args true" do
+    expr = %Expr.Function{
+      f: :"starts-with",
+      args: [
+        %Expr.Literal{value: "hello"},
+        %Expr.Literal{value: "hell"}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "starts-with two args false" do
+    expr = %Expr.Function{
+      f: :"starts-with",
+      args: [
+        %Expr.Literal{value: "hello"},
+        %Expr.Literal{value: "no"}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = false
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # contains
+
+  test "contains two args true" do
+    expr = %Expr.Function{
+      f: :contains,
+      args: [
+        %Expr.Literal{value: "hello"},
+        %Expr.Literal{value: "ello"}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "contains two args false" do
+    expr = %Expr.Function{
+      f: :contains,
+      args: [
+        %Expr.Literal{value: "hello"},
+        %Expr.Literal{value: "no"}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = false
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # substring-before
+
+  test "substring-before two args" do
+    expr = %Expr.Function{
+      f: :"substring-before",
+      args: [
+        %Expr.Literal{value: "Hello, World!"},
+        %Expr.Literal{value: ","}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = "Hello"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # substring-after
+
+  test "substring-after two args" do
+    expr = %Expr.Function{
+      f: :"substring-after",
+      args: [
+        %Expr.Literal{value: "Hello, World!"},
+        %Expr.Literal{value: ","}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = " World!"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # substring
+
+  test "substring two args" do
+    expr = %Expr.Function{
+      f: :substring,
+      args: [
+        %Expr.Literal{value: "12345"},
+        %Expr.Number{value: "2"}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = "2345"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "substring two args NaN" do
+    expr = %Expr.Function{
+      f: :substring,
+      args: [
+        %Expr.Literal{value: "12345"},
+        %Expr.Number{value: :NaN}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = ""
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "substring two args Infinity" do
+    expr = %Expr.Function{
+      f: :substring,
+      args: [
+        %Expr.Literal{value: "12345"},
+        %Expr.Number{value: :Infinity}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = ""
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "substring two args -Infinity" do
+    expr = %Expr.Function{
+      f: :substring,
+      args: [
+        %Expr.Literal{value: "12345"},
+        %Expr.Number{value: :"-Infinity"}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = "12345"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "substring three args simple" do
+    expr = %Expr.Function{
+      f: :substring,
+      args: [
+        %Expr.Literal{value: "12345"},
+        %Expr.Number{value: 2},
+        %Expr.Number{value: 3}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = "234"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "substring three args any NaN" do
+    expr = %Expr.Function{
+      f: :substring,
+      args: [
+        %Expr.Literal{value: "12345"},
+        %Expr.Number{value: 2},
+        %Expr.Number{value: :NaN}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = ""
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "substring three args Infinity start" do
+    expr = %Expr.Function{
+      f: :substring,
+      args: [
+        %Expr.Literal{value: "12345"},
+        %Expr.Number{value: :Infinity},
+        %Expr.Number{value: 5}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = ""
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "substring three args neg start len too short" do
+    expr = %Expr.Function{
+      f: :substring,
+      args: [
+        %Expr.Literal{value: "12345"},
+        %Expr.Number{value: -3},
+        %Expr.Number{value: 3}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = ""
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "substring three args neg start and len" do
+    expr = %Expr.Function{
+      f: :substring,
+      args: [
+        %Expr.Literal{value: "12345"},
+        %Expr.Number{value: -3},
+        %Expr.Number{value: 5}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = "1"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "substring three args neg start and Infinity len" do
+    expr = %Expr.Function{
+      f: :substring,
+      args: [
+        %Expr.Literal{value: "12345"},
+        %Expr.Number{value: -3},
+        %Expr.Number{value: :Infinity}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = "12345"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "substring three args -Infinity start and Infinity len" do
+    expr = %Expr.Function{
+      f: :substring,
+      args: [
+        %Expr.Literal{value: "12345"},
+        %Expr.Number{value: :"-Infinity"},
+        %Expr.Number{value: :Infinity}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = "12345"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "substring three args valid start and neg len" do
+    expr = %Expr.Function{
+      f: :substring,
+      args: [
+        %Expr.Literal{value: "12345"},
+        %Expr.Number{value: 2},
+        %Expr.Number{value: -1}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = ""
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # string-length
+
+  test "string-length no args" do
+    expr = %Expr.Function{
+      f: :"string-length",
+      args: []}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 5
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "string-length one arg" do
+    expr = %Expr.Function{
+      f: :"string-length",
+      args: [%Expr.Literal{value: "Hi"}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 2
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # normalize-space
+
+  test "normalize-space no args" do
+    expr = %Expr.Function{
+      f: :"normalize-space",
+      args: []}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = "12345"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "normalize-space one arg" do
+    expr = %Expr.Function{
+      f: :"normalize-space",
+      args: [%Expr.Literal{value: "     Hello,     World!  "}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = "Hello, World!"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # boolean
+
+  test "boolean one arg true" do
+    expr = %Expr.Function{
+      f: :boolean,
+      args: [%Expr.Literal{value: "Hi"}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "boolean one arg false" do
+    expr = %Expr.Function{
+      f: :boolean,
+      args: [%Expr.Literal{value: ""}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = false
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # not
+
+  test "not one arg" do
+    expr = %Expr.Function{
+      f: :not,
+      args: [%Expr.Function{
+                f: :boolean,
+                args: [%Expr.Literal{value: ""}]}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # true
+
+  test "true no args" do
+    expr = %Expr.Function{
+      f: :true,
+      args: []}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = true
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # false
+
+  test "false no args" do
+    expr = %Expr.Function{
+      f: :false,
+      args: []}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = false
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # number
+
+  test "number no args" do
+    expr = %Expr.Function{
+      f: :number,
+      args: []}
+    node = Document.get_node(@document, 7)
+    context = %{}
+    expected = 2
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "number one arg" do
+    expr = %Expr.Function{
+      f: :number,
+      args: [%Expr.Function{f: :false, args: []}]}
+    node = Document.get_node(@document, 7)
+    context = %{}
+    expected = 0
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # sum
+
+  test "sum one arg" do
+    expr = %Expr.Function{
+      f: :sum,
+      args: [
+        %Expr.Path{
+          steps: [
+            %Expr.Step{
+              combinator: %Combinator.DescendantsOrSelf{selector: nil},
+              predicates: [%Expr.NodeType{type: :node}]},
+            %Expr.Step{
+              combinator: %Combinator.Children{selector: nil},
+              predicates: [%Expr.NameTest{ namespace: nil, tag: "p"}]}],
+          type: :abs}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 15
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # floor
+
+  test "floor one arg" do
+    expr = %Expr.Function{
+      f: :floor,
+      args: [%Expr.Number{value: 2.6}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 2
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # ceiling
+
+  test "ceiling one arg" do
+    expr = %Expr.Function{
+      f: :ceiling,
+      args: [%Expr.Number{value: 2.5}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 3
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  # round
+
+  test "round one arg" do
+    expr = %Expr.Function{
+      f: :round,
+      args: [%Expr.Number{value: 2.4}]}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 2
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+end

--- a/test/meeseeks/selector/xpath/expr/name_test_test.exs
+++ b/test/meeseeks/selector/xpath/expr/name_test_test.exs
@@ -1,0 +1,132 @@
+defmodule Meeseeks.Selector.XPath.Expr.NameTestTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.XPath.Expr
+
+  test "any element" do
+    expr = %Expr.NameTest{tag: "*"}
+    node = %Document.Element{id: 0, namespace: "any", tag: "element"}
+    document = nil
+    context = nil
+    expected = true
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "matching namespace any tag" do
+    expr = %Expr.NameTest{namespace: "hello", tag: "*"}
+    node = %Document.Element{id: 0, namespace: "hello", tag: "world"}
+    document = nil
+    context = nil
+    expected = true
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "non-matching namespace any tag" do
+    expr = %Expr.NameTest{namespace: "hello", tag: "*"}
+    node = %Document.Element{id: 0, namespace: "goodbye", tag: "world"}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "namespace any tag without namespace" do
+    expr = %Expr.NameTest{namespace: "hello", tag: "*"}
+    node = %Document.Element{id: 0, tag: "element"}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "matching namespace no tag" do
+    expr = %Expr.NameTest{namespace: "hello"}
+    node = %Document.Element{id: 0, namespace: "hello", tag: "world"}
+    document = nil
+    context = nil
+    expected = true
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "non-matching namespace no name" do
+    expr = %Expr.NameTest{namespace: "hello"}
+    node = %Document.Element{id: 0, namespace: "goodbye", tag: "world"}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "namespace no tag without namespace" do
+    expr = %Expr.NameTest{namespace: "hello"}
+    node = %Document.Element{id: 0, tag: "nope"}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "matching tag" do
+    expr = %Expr.NameTest{tag: "world"}
+    node = %Document.Element{id: 0, namespace: "hello", tag: "world"}
+    document = nil
+    context = nil
+    expected = true
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "non-matching tag" do
+    expr = %Expr.NameTest{tag: "world"}
+    node = %Document.Element{id: 0, namespace: "goodmorning", tag: "vietnam"}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "matching namespace and tag" do
+    expr = %Expr.NameTest{namespace: "hello", tag: "world"}
+    node = %Document.Element{id: 0, namespace: "hello", tag: "world"}
+    document = nil
+    context = nil
+    expected = true
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "matching namespace non-matching tag" do
+    expr = %Expr.NameTest{namespace: "hello", tag: "world"}
+    node = %Document.Element{id: 0, namespace: "hello", tag: "goodbye"}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "non-matching namespace matching tag" do
+    expr = %Expr.NameTest{namespace: "hello", tag: "world"}
+    node = %Document.Element{id: 0, namespace: "goodbye", tag: "world"}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "namespace and tag without namespace" do
+    expr = %Expr.NameTest{namespace: "hello", tag: "world"}
+    node = %Document.Element{id: 0, tag: "world"}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "non-element node doesn't match" do
+    expr = %Expr.NameTest{tag: "world"}
+    node = %Document.Text{id: 1}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+end

--- a/test/meeseeks/selector/xpath/expr/namespace_name_test_test.exs
+++ b/test/meeseeks/selector/xpath/expr/namespace_name_test_test.exs
@@ -1,0 +1,69 @@
+defmodule Meeseeks.Selector.XPath.Expr.NamespaceNameTestTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.XPath.Expr
+
+  test "any name" do
+    expr = %Expr.NamespaceNameTest{name: "*"}
+    node = "xml"
+    document = nil
+    context = nil
+    expected = true
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "no namespace matching name" do
+    expr = %Expr.NamespaceNameTest{name: "xml"}
+    node = "xml"
+    document = nil
+    context = nil
+    expected = true
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "no namespace non-matching name" do
+    expr = %Expr.NamespaceNameTest{name: "xml"}
+    node = "json"
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "empty namespace matching name" do
+    expr = %Expr.NamespaceNameTest{namespace: "", name: "xml"}
+    node = "xml"
+    document = nil
+    context = nil
+    expected = true
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "empty namespace non-matching name" do
+    expr = %Expr.NamespaceNameTest{namespace: "", name: "xml"}
+    node = "json"
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "any namespace" do
+    expr = %Expr.NamespaceNameTest{namespace: "xml"}
+    node = "xml"
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+
+  test "non-attribute node doesn't match" do
+    expr = %Expr.NamespaceNameTest{name: "xml"}
+    node = %Document.Text{id: 1}
+    document = nil
+    context = nil
+    expected = false
+    assert Expr.eval(expr, node, document, context) == expected
+  end
+end

--- a/test/meeseeks/selector/xpath/expr/negative_test.exs
+++ b/test/meeseeks/selector/xpath/expr/negative_test.exs
@@ -1,0 +1,52 @@
+defmodule Meeseeks.Selector.XPath.Expr.NegativeTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.XPath.Expr
+
+  @document Meeseeks.parse(
+    {"book", [], [
+        {"chapter", [], [
+            {"page", [], ["1"]},
+            {"page", [], ["2"]}]}]})
+
+  test "negate positive" do
+    expr = %Expr.Negative{e: %Expr.Number{value: 2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = -2
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "negate negative" do
+    expr = %Expr.Negative{e: %Expr.Number{value: -2}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = 2
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "negate NaN" do
+    expr = %Expr.Negative{e: %Expr.Number{value: :NaN}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = :NaN
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "negate Infinity" do
+    expr = %Expr.Negative{e: %Expr.Number{value: :Infinity}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = :"-Infinity"
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "negate -Infinity" do
+    expr = %Expr.Negative{e: %Expr.Number{value: :"-Infinity"}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = :Infinity
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+end

--- a/test/meeseeks/selector/xpath/expr/path_test.exs
+++ b/test/meeseeks/selector/xpath/expr/path_test.exs
@@ -1,0 +1,84 @@
+defmodule Meeseeks.Selector.XPath.Expr.PathTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.Combinator
+  alias Meeseeks.Selector.XPath.Expr
+
+  @document Meeseeks.parse(
+    {"book", [], [
+        {"chapter", [], [
+            {"page", [], ["1"]},
+            {"page", [], ["2"]}]}]})
+
+  test "absolute path" do
+    expr = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "book"}]},
+        %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "chapter"}]}],
+      type: :abs}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = Document.get_nodes(@document, [2])
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "relative path" do
+    expr = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "page"}]}],
+      type: :rel}
+    node = Document.get_node(@document, 3)
+    context = %{}
+    expected = Document.get_nodes(@document, [3])
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "path no matches" do
+    expr = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "missing"}]}],
+      type: :rel}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = []
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "path one match" do
+    expr = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "chapter"}]}],
+      type: :rel}
+    node = Document.get_node(@document, 2)
+    context = %{}
+    expected = Document.get_nodes(@document, [2])
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "path multiple matches" do
+    expr = %Expr.Path{
+      steps: [
+        %Expr.Step{
+          combinator: %Combinator.DescendantsOrSelf{selector: nil},
+          predicates: [%Expr.NodeType{type: :node}]},
+        %Expr.Step{
+          combinator: %Combinator.Children{selector: nil},
+          predicates: [%Expr.NameTest{ namespace: nil, tag: "page"}]}],
+      type: :abs}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = Document.get_nodes(@document, [3, 5])
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+end

--- a/test/meeseeks/selector/xpath/expr/step_test.exs
+++ b/test/meeseeks/selector/xpath/expr/step_test.exs
@@ -1,0 +1,43 @@
+defmodule Meeseeks.Selector.XPath.Expr.StepTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.Combinator
+  alias Meeseeks.Selector.XPath.Expr
+
+  @document Meeseeks.parse(
+    {"book", [], [
+        {"chapter", [], [
+            {"page", [], ["1"]},
+            {"page", [], ["2"]}]}]})
+
+  test "step no matches" do
+    expr = %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                      predicates: [%Expr.NameTest{namespace: nil,
+                                                  tag: "chapter"}]}
+    node = Document.get_node(@document, 1)
+    context = %{}
+    expected = []
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "step one match" do
+    expr = %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                      predicates: [%Expr.NameTest{namespace: nil,
+                                                  tag: "chapter"}]}
+    node = Document.get_node(@document, 1)
+    context = %{}
+    expected = Document.get_nodes(@document, [2])
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "step multiple matches" do
+    expr = %Expr.Step{combinator: %Combinator.Descendants{selector: nil},
+                      predicates: [%Expr.NameTest{namespace: nil,
+                                                  tag: "page"}]}
+    node = Document.get_node(@document, 1)
+    context = %{}
+    expected = Document.get_nodes(@document, [3, 5])
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+end

--- a/test/meeseeks/selector/xpath/expr/union_test.exs
+++ b/test/meeseeks/selector/xpath/expr/union_test.exs
@@ -1,0 +1,82 @@
+defmodule Meeseeks.Selector.XPath.Expr.UnionTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Document
+  alias Meeseeks.Selector.Combinator
+  alias Meeseeks.Selector.XPath.Expr
+
+  @document Meeseeks.parse(
+    {"book", [], [
+        {"chapter", [], [
+            {"page", [], ["1"]},
+            {"page", [], ["2"]}]}]})
+
+  test "union both match" do
+    expr = %Expr.Union{
+      e1: %Expr.Path{
+        steps: [
+          %Expr.Step{
+            combinator: %Combinator.Self{selector: nil},
+            predicates: [%Expr.NameTest{namespace: nil, tag: "book"}]}],
+        type: :abs},
+      e2: %Expr.Path{
+        steps: [
+          %Expr.Step{
+            combinator: %Combinator.DescendantsOrSelf{selector: nil},
+            predicates: [%Expr.NodeType{type: :node}]},
+          %Expr.Step{
+            combinator: %Combinator.Children{selector: nil},
+            predicates: [%Expr.NameTest{namespace: nil, tag: "chapter"}]}],
+        type: :abs}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = Document.get_nodes(@document, [1, 2])
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "union one matches" do
+    expr = %Expr.Union{
+      e1: %Expr.Path{
+        steps: [
+          %Expr.Step{
+            combinator: %Combinator.Self{selector: nil},
+            predicates: [%Expr.NameTest{namespace: nil, tag: "textbook"}]}],
+        type: :abs},
+      e2: %Expr.Path{
+        steps: [
+          %Expr.Step{
+            combinator: %Combinator.DescendantsOrSelf{selector: nil},
+            predicates: [%Expr.NodeType{type: :node}]},
+          %Expr.Step{
+            combinator: %Combinator.Children{selector: nil},
+            predicates: [%Expr.NameTest{namespace: nil, tag: "chapter"}]}],
+        type: :abs}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = Document.get_nodes(@document, [2])
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+
+  test "union neither matches" do
+    expr = %Expr.Union{
+      e1: %Expr.Path{
+        steps: [
+          %Expr.Step{
+            combinator: %Combinator.Self{selector: nil},
+            predicates: [%Expr.NameTest{namespace: nil, tag: "textbook"}]}],
+        type: :abs},
+      e2: %Expr.Path{
+        steps: [
+          %Expr.Step{
+            combinator: %Combinator.DescendantsOrSelf{selector: nil},
+            predicates: [%Expr.NodeType{type: :node}]},
+          %Expr.Step{
+            combinator: %Combinator.Children{selector: nil},
+            predicates: [%Expr.NameTest{namespace: nil, tag: "lesson"}]}],
+        type: :abs}}
+    node = Document.get_node(@document, 4)
+    context = %{}
+    expected = []
+    assert Expr.eval(expr, node, @document, context) == expected
+  end
+end

--- a/test/meeseeks/selector/xpath/parser_test.exs
+++ b/test/meeseeks/selector/xpath/parser_test.exs
@@ -1,0 +1,523 @@
+defmodule Meeseeks.Selector.XPath.ParserTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Selector.{Combinator, XPath}
+  alias Meeseeks.Selector.XPath.{Expr, Parser, Tokenizer}
+
+  # abs
+
+  test "root only" do
+    tokens = Tokenizer.tokenize("/")
+    assert_raise ErlangError, fn ->
+      Parser.parse_expression(tokens)
+    end
+  end
+
+  test "abs wildcard" do
+    tokens = Tokenizer.tokenize("/*")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "*"}]}],
+      type: :abs}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  test "abs only" do
+    tokens = Tokenizer.tokenize("/root")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "root"}]}],
+      type: :abs}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  test "abs abbreviated step" do
+    tokens = Tokenizer.tokenize("/root/child")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "root"}]},
+        %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "child"}]}],
+      type: :abs}
+
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  test "abs explicit step" do
+    tokens = Tokenizer.tokenize("/root/descendant::descendant")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "root"}]},
+        %Expr.Step{combinator: %Combinator.Descendants{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "descendant"}]}],
+      type: :abs}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  test "abbreviated abs" do
+    tokens = Tokenizer.tokenize("//*")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.DescendantsOrSelf{selector: nil},
+                   predicates: [%Expr.NodeType{type: :node}]},
+        %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "*"}]}],
+      type: :abs}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # rel
+
+  test "rel wildcard only" do
+    tokens = Tokenizer.tokenize("*")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "*"}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  test "rel only" do
+    tokens = Tokenizer.tokenize("node")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "node"}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  test "rel appreviated step" do
+    tokens = Tokenizer.tokenize("node/child")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "node"}]},
+        %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "child"}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  test "rel explicit step" do
+    tokens = Tokenizer.tokenize("node/ancestor::ancestor")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "node"}]},
+        %Expr.Step{combinator: %Combinator.Ancestors{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "ancestor"}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # abbreviated step
+
+  test "self node" do
+    tokens = Tokenizer.tokenize("/./child")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                   predicates: [%Expr.NodeType{type: :node}]},
+        %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "child"}]}],
+      type: :abs}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  test "parent node" do
+    tokens = Tokenizer.tokenize("../self::parent")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Parent{selector: nil},
+                   predicates: [%Expr.NodeType{type: :node}]},
+        %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "parent"}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  test "child" do
+    tokens = Tokenizer.tokenize("./child")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                   predicates: [%Expr.NodeType{type: :node}]},
+        %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "child"}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  test "descendant or self" do
+    tokens = Tokenizer.tokenize(".//descendant")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                   predicates: [%Expr.NodeType{type: :node}]},
+        %Expr.Step{combinator: %Combinator.DescendantsOrSelf{selector: nil},
+                   predicates: [%Expr.NodeType{type: :node}]},
+        %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                   predicates: [%Expr.NameTest{namespace: nil,
+                                               tag: "descendant"}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # abbreviated axis
+
+  test "attribute axis" do
+    tokens = Tokenizer.tokenize("@*")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{
+          combinator: %XPath.Combinator.Attributes{selector: nil},
+          predicates: [%XPath.Expr.AttributeNameTest{name: "*",
+                                                     namespace: nil}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # node type
+
+  test "node type" do
+    tokens = Tokenizer.tokenize("/comment()")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                   predicates: [%Expr.NodeType{type: :comment}]}],
+      type: :abs}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # processing instruction
+
+  test "processing instruction" do
+    tokens = Tokenizer.tokenize("/processing-instruction('xml-spreadsheet')")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Self{selector: nil},
+                   predicates: [%Expr.ProcessingInstruction{name: 'xml-spreadsheet'}]}],
+      type: :abs}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # union
+
+  test "union" do
+    tokens = Tokenizer.tokenize("this|that")
+    expression = %Expr.Union{
+      e1: %Expr.Path{
+        steps: [
+          %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                     predicates: [%Expr.NameTest{namespace: nil,
+                                                 tag: "this"}]}],
+        type: :rel},
+      e2: %Expr.Path{
+        steps: [
+          %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                     predicates: [%Expr.NameTest{namespace: nil,
+                                                 tag: "that"}]}],
+        type: :rel}}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # filter
+
+  test "filter" do
+    tokens = Tokenizer.tokenize("(this|that)[@type != 'the-other']")
+    expression = %Expr.Filter{
+      e: %Expr.Union{
+        e1: %Expr.Path{
+          steps: [
+            %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                       predicates: [%Expr.NameTest{namespace: nil,
+                                                   tag: "this"}]}],
+          type: :rel},
+        e2: %Expr.Path{
+          steps: [
+            %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                       predicates: [%Expr.NameTest{namespace: nil,
+                                                   tag: "that"}]}],
+          type: :rel}},
+      predicate: %Expr.Predicate{
+        e: %Expr.Comparative{
+          e1: %Expr.Path{
+            steps: [
+              %Expr.Step{
+                combinator: %XPath.Combinator.Attributes{selector: nil},
+                predicates: [%Expr.AttributeNameTest{name: "type",
+                                                     namespace: nil}]}],
+            type: :rel},
+          e2: %Expr.Literal{value: "the-other"},
+          op: :!=}}}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # predicate
+
+  test "predicate number" do
+    tokens = Tokenizer.tokenize("*[2]")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{combinator: %Combinator.Children{selector: nil},
+                   predicates: [
+                     %Expr.NameTest{namespace: nil,
+                                    tag: "*"},
+                     %Expr.Predicate{
+                       e: %Meeseeks.Selector.XPath.Expr.Number{value: 2}}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  test "predicate expr" do
+    tokens = Tokenizer.tokenize("*[@id = 'good']")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{
+          combinator: %Combinator.Children{selector: nil},
+          predicates: [
+            %Expr.NameTest{namespace: nil,
+                           tag: "*"},
+            %Expr.Predicate{
+              e: %Expr.Comparative{
+                e1: %Expr.Path{
+                  steps: [
+                    %Expr.Step{
+                      combinator: %XPath.Combinator.Attributes{selector: nil},
+                      predicates: [
+                        %Expr.AttributeNameTest{name: "id",
+                                                namespace: nil}]}],
+                  type: :rel},
+                e2: %Expr.Literal{value: "good"},
+                op: :=}}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # literal
+
+  test "literal" do
+    tokens = Tokenizer.tokenize("*[@id = 'good']")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{
+          combinator: %Combinator.Children{selector: nil},
+          predicates: [
+            %Expr.NameTest{namespace: nil,
+                           tag: "*"},
+            %Expr.Predicate{
+              e: %Expr.Comparative{
+                e1: %Expr.Path{
+                  steps: [
+                    %Expr.Step{
+                      combinator: %XPath.Combinator.Attributes{selector: nil},
+                      predicates: [
+                        %Expr.AttributeNameTest{name: "id",
+                                                namespace: nil}]}],
+                  type: :rel},
+                e2: %Expr.Literal{value: "good"},
+                op: :=}}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # number
+
+  test "number" do
+    tokens = Tokenizer.tokenize("*[position() = 2]")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{
+          combinator: %Combinator.Children{selector: nil},
+          predicates: [
+            %Expr.NameTest{namespace: nil,
+                           tag: "*"},
+            %Expr.Predicate{
+              e: %Expr.Comparative{
+                e1: %Expr.Function{args: [],
+                                   f: :position},
+                e2: %Expr.Number{value: 2},
+                op: :=}}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # function
+
+  test "function no args" do
+    tokens = Tokenizer.tokenize("*[last()]")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{
+          combinator: %Combinator.Children{selector: nil},
+          predicates: [
+            %Expr.NameTest{namespace: nil,
+                           tag: "*"},
+            %Expr.Predicate{
+              e: %Expr.Function{args: [], f: :last}}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  test "function with args" do
+    tokens = Tokenizer.tokenize("*[string(./*) = '123']")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{
+          combinator: %Combinator.Children{selector: nil},
+          predicates: [
+            %Expr.NameTest{namespace: nil,
+                           tag: "*"},
+            %Expr.Predicate{
+              e: %Expr.Comparative{
+                e1: %Expr.Function{
+                  args: [
+                    %Expr.Path{
+                      steps: [
+                        %Expr.Step{
+                          combinator: %Combinator.Self{selector: nil},
+                          predicates: [%Expr.NodeType{type: :node}]},
+                        %Expr.Step{
+                          combinator: %Combinator.Children{selector: nil},
+                          predicates: [%Expr.NameTest{namespace: nil,
+                                                      tag: "*"}]}],
+                      type: :rel}],
+                  f: :string},
+                e2: %Expr.Literal{value: "123"},
+                op: :=}}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # boolean
+
+  test "boolean" do
+    tokens = Tokenizer.tokenize("*[postition() = last() and @class = 'odd']")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{
+          combinator: %Combinator.Children{selector: nil},
+          predicates: [
+            %Expr.NameTest{namespace: nil,
+                           tag: "*"},
+            %Expr.Predicate{
+              e: %Expr.Boolean{
+                e1: %Expr.Comparative{
+                  e1: %Expr.Function{
+                    args: [],
+                    f: :postition},
+                  e2: %Expr.Function{
+                    args: [],
+                    f: :last},
+                  op: :=},
+                e2: %Expr.Comparative{
+                  e1: %Expr.Path{
+                    steps: [
+                      %Expr.Step{
+                        combinator: %XPath.Combinator.Attributes{selector: nil},
+                        predicates: [%Expr.AttributeNameTest{
+                                        name: "class",
+                                        namespace: nil}]}],
+                    type: :rel},
+                  e2: %Expr.Literal{value: "odd"},
+                  op: :=},
+                op: :and}}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # comparative
+
+  test "comparative" do
+    tokens = Tokenizer.tokenize("*[postition() <= 3]")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{
+          combinator: %Combinator.Children{selector: nil},
+          predicates: [
+            %Expr.NameTest{namespace: nil,
+                           tag: "*"},
+            %Expr.Predicate{
+              e: %Expr.Comparative{
+                e1: %Expr.Function{
+                  args: [],
+                  f: :postition},
+                e2: %Expr.Number{value: 3},
+                op: :<=}}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # arithmetic
+
+  test "arithmetic" do
+    tokens = Tokenizer.tokenize("*[last() - 1]")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{
+          combinator: %Combinator.Children{selector: nil},
+          predicates: [
+            %Expr.NameTest{namespace: nil,
+                           tag: "*"},
+            %Expr.Predicate{
+              e: %Expr.Arithmetic{e1: %Expr.Function{args: [],
+                                                     f: :last},
+                                  e2: %Expr.Number{value: 1},
+                                  op: :-}}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # negative
+
+  test "negative" do
+    tokens = Tokenizer.tokenize("*[-(1 - last())]")
+    expression = %Expr.Path{
+      steps: [
+        %Expr.Step{
+          combinator: %Combinator.Children{selector: nil},
+          predicates: [
+            %Expr.NameTest{namespace: nil,
+                           tag: "*"},
+            %Expr.Predicate{
+              e: %Expr.Negative{
+                e: %Expr.Arithmetic{
+                  e1: %Expr.Number{value: 1},
+                  e2: %Expr.Function{args: [],
+                                     f: :last},
+                  op: :-}}}]}],
+      type: :rel}
+    assert Parser.parse_expression(tokens) == expression
+  end
+
+  # no var_refs
+
+  test "no var-refs" do
+    tokens = Tokenizer.tokenize("*[string(.) = $val]")
+    assert_raise ErlangError, fn ->
+      Parser.parse_expression(tokens)
+    end
+  end
+end

--- a/test/meeseeks/selector/xpath_test.exs
+++ b/test/meeseeks/selector/xpath_test.exs
@@ -1,0 +1,232 @@
+defmodule Meeseeks.Selector.XPathTest do
+  use ExUnit.Case
+
+  alias Meeseeks.Selector.{Combinator, Element, Node, Root, XPath}
+  alias Meeseeks.Selector.XPath.Expr
+
+  test "single segment wildcard selector" do
+    xpath = "*"
+    expected = %Element{
+      combinator: %Combinator.Children{
+        selector: %Element{
+          combinator: nil,
+          filters: nil,
+          selectors: [%Element.Tag{value: "*"}]}},
+      filters: nil,
+      selectors: []}
+    assert XPath.compile_selectors(xpath) == expected
+  end
+
+  test "single segment abs selector" do
+    xpath = "/root"
+    expected = %Root{
+      combinator: nil,
+      filters: nil,
+      selectors: [%Element.Tag{value: "root"}]}
+    assert XPath.compile_selectors(xpath) == expected
+  end
+
+  test "single segment rel selector" do
+    xpath = "node"
+    expected = %Element{
+      combinator: %Combinator.Children{
+        selector: %Element{
+          combinator: nil,
+          filters: nil,
+          selectors: [%Element.Tag{value: "node"}]}},
+      filters: nil,
+      selectors: []}
+    assert XPath.compile_selectors(xpath) == expected
+  end
+
+  test "single segment selector with predicate" do
+    xpath = "node[2]"
+    expected = %Element{
+      combinator: %Combinator.Children{
+        selector: %Element{
+          combinator: nil,
+          filters: [
+            %XPath.Predicate{e: %Expr.Predicate{e: %Expr.Number{value: 2}}}],
+          selectors: [%Element.Tag{value: "node"}]}},
+      filters: nil,
+      selectors: []}
+    assert XPath.compile_selectors(xpath) == expected
+  end
+
+  test "single segment selector with axis" do
+    xpath = "descendant::node"
+    expected = %Element{
+      combinator: %Combinator.Descendants{
+        selector: %Element{
+          combinator: nil,
+          filters: nil,
+          selectors: [%Element.Tag{value: "node"}]}},
+      filters: nil,
+      selectors: []}
+    assert XPath.compile_selectors(xpath) == expected
+  end
+
+  test "multiple segment abs selector" do
+    xpath = "/root/child"
+    expected = %Root{
+      combinator: %Combinator.Children{
+        selector: %Element{
+          combinator: nil,
+          filters: nil,
+          selectors: [%Element.Tag{value: "child"}]}},
+      filters: nil,
+      selectors: [%Element.Tag{value: "root"}]}
+    assert XPath.compile_selectors(xpath) == expected
+  end
+
+  test "multiple segment rel selector" do
+    xpath = "node/child"
+    expected = %Element{
+      combinator: %Combinator.Children{
+        selector: %Element{
+          combinator: %Combinator.Children{
+            selector: %Element{
+              combinator: nil,
+              filters: nil,
+              selectors: [%Element.Tag{value: "child"}]}},
+          filters: nil,
+          selectors: [%Element.Tag{value: "node"}]}},
+      filters: nil,
+      selectors: []}
+    assert XPath.compile_selectors(xpath) == expected
+  end
+
+  test "multiple segment selector with predicates" do
+    xpath = "node[4]/child[last()]"
+    expected = %Element{
+      combinator: %Combinator.Children{
+        selector: %Element{
+          combinator: %Combinator.Children{
+            selector: %Element{
+              combinator: nil,
+              filters: [
+                %XPath.Predicate{
+                  e: %Expr.Predicate{
+                    e: %Expr.Function{args: [], f: :last}}}],
+              selectors: [%Element.Tag{value: "child"}]}},
+          filters: [
+            %XPath.Predicate{e: %Expr.Predicate{e: %Expr.Number{value: 4}}}],
+          selectors: [%Element.Tag{value: "node"}]}},
+      filters: nil,
+      selectors: []}
+    assert XPath.compile_selectors(xpath) == expected
+  end
+
+  test "abbreviated parent selector" do
+    xpath = "../child"
+    expected = %Node{
+      combinator: %Combinator.Parent{
+        selector: %Element{
+          combinator: %Combinator.Children{
+            selector: %Element{
+              combinator: nil,
+              filters: nil,
+              selectors: [%Element.Tag{value: "child"}]}},
+          filters: nil,
+          selectors: []}},
+      filters: nil,
+      selectors: []}
+    assert XPath.compile_selectors(xpath) == expected
+  end
+
+  test "abbreviated root descendant-or-self selector" do
+    xpath = "//child"
+    expected = %Element{
+      combinator: %Combinator.Children{
+        selector: %Element{
+          combinator: nil,
+          filters: nil,
+          selectors: [%Element.Tag{value: "child"}]}},
+      filters: nil,
+      selectors: []}
+    assert XPath.compile_selectors(xpath) == expected
+  end
+
+  test "abbreviated node descendant-or-self selector" do
+    xpath = ".//child"
+    expected = %Node{
+      combinator: %Combinator.DescendantsOrSelf{
+        selector: %Element{
+          combinator: %Combinator.Children{
+            selector: %Element{
+              combinator: nil,
+              filters: nil,
+              selectors: [%Element.Tag{value: "child"}]}},
+          filters: nil,
+          selectors: []}},
+      filters: nil,
+      selectors: []}
+    assert XPath.compile_selectors(xpath) == expected
+  end
+
+  test "abbreviated attribute selector" do
+    xpath = "@*"
+    expected = %Node{
+      combinator: %XPath.Combinator.Attributes{
+        selector: %Node{
+          combinator: nil,
+          selectors: [
+            %XPath.Predicate{
+              e: %Expr.AttributeNameTest{name: "*",
+                                         namespace: nil}}]}},
+      selectors: []}
+    assert XPath.compile_selectors(xpath) == expected
+  end
+
+  test "simple union selector" do
+    xpath = "/root|./child"
+    expected = [
+      %Root{
+        combinator: nil,
+        filters: nil,
+        selectors: [%Element.Tag{value: "root"}]},
+      %Element{
+        combinator: %Combinator.Children{
+          selector: %Element{
+            combinator: nil,
+            filters: nil,
+            selectors: [%Element.Tag{value: "child"}]}},
+        filters: nil,
+        selectors: []}]
+    assert XPath.compile_selectors(xpath) == expected
+  end
+
+  test "complex union selector" do
+    xpath = "node[4]/child[last()]|/comment()"
+    expected = [
+      %Element{
+        combinator: %Combinator.Children{
+          selector: %Element{
+            combinator: %Combinator.Children{
+              selector: %Element{
+                combinator: nil,
+                filters: [
+                  %XPath.Predicate{
+                    e: %Expr.Predicate{
+                      e: %Expr.Function{args: [], f: :last}}}],
+                selectors: [%Element.Tag{value: "child"}]}},
+            filters: [
+              %XPath.Predicate{
+                e: %Expr.Predicate{e: %Expr.Number{value: 4}}}],
+            selectors: [%Element.Tag{value: "node"}]}},
+        filters: nil,
+        selectors: []},
+      %Root{
+        combinator: nil,
+        filters: nil,
+        selectors: [%XPath.Predicate{e: %Expr.NodeType{type: :comment}}]}]
+    assert XPath.compile_selectors(xpath) == expected
+  end
+
+  test "no top-level filters" do
+    xpath = "(this|that)[2]"
+    assert_raise RuntimeError, fn ->
+      XPath.compile_selectors(xpath)
+    end
+  end
+end

--- a/test/meeseeks/xpath_test.exs
+++ b/test/meeseeks/xpath_test.exs
@@ -1,0 +1,282 @@
+defmodule Meeseeks.XPath_Test do
+  use ExUnit.Case
+  doctest Meeseeks.XPath
+
+  import Meeseeks.XPath
+
+  alias Meeseeks.Result
+
+  @document Meeseeks.Parser.parse(
+    """
+    <!-- Test Document -->
+    <html>
+      <head></head>
+      <body>
+        <!-- Main -->
+        <div id="main">
+	 <p id="first-p">1</p>
+	 <p data-id="second-p">2</p>
+	 <p class="a b">3</p>
+         <div class="secondary">
+           <p>4</p>
+           <p class="b c">5</p>
+         </div>
+	</div>
+      </body>
+    </html>
+    """
+  )
+
+  test "absolute path single segment" do
+    selector = xpath("/comment()")
+    expected = [%Result{id: 1, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "absolute path multiple segments" do
+    selector = xpath("/html/head")
+    expected = [%Result{id: 3, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "rel path single segment" do
+    selector = xpath("head")
+    expected = [%Result{id: 3, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "rel path dot single segment" do
+    selector = xpath("./head")
+    expected = [%Result{id: 3, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "rel path multiple segments" do
+    selector = xpath("body/div")
+    expected = [%Result{id: 9, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "abbrevated descendants" do
+    selector = xpath("/html//div")
+    expected = [%Result{id: 9, document: @document},
+                %Result{id: 20, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "root nodes" do
+    selector = xpath("/node()")
+    expected = [%Result{id: 1, document: @document},
+                %Result{id: 2, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "root elements" do
+    selector = xpath("/*")
+    expected = [%Result{id: 2, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "selector union" do
+    selector = xpath("/html|./head")
+    expected = [%Result{id: 2, document: @document},
+                %Result{id: 3, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "nodes that are 4th child of parent" do
+    selector = xpath("//node()[4]")
+    expected = [%Result{id: 9, document: @document},
+                %Result{id: 14, document: @document},
+                %Result{id: 25, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "4th node" do
+    selector = xpath(".[4]")
+    expected = [%Result{id: 4, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "4th element" do
+    selector = xpath("self::*[4]")
+    expected = [%Result{id: 9, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "second child p" do
+    selector = xpath("//p[2]")
+    expected = [%Result{id: 14, document: @document},
+                %Result{id: 25, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "every child p that isn't the second child" do
+    selector = xpath("//p[not(position() = 2)]")
+    expected = [%Result{id: 11, document: @document},
+                %Result{id: 17, document: @document},
+                %Result{id: 22, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "second child p interpolation" do
+    p = 2
+    selector = xpath("//p[#{p}]")
+    expected = [%Result{id: 14, document: @document},
+                %Result{id: 25, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "second child p concat" do
+    p = 2
+    selector = xpath("//p[" <> Integer.to_string(p) <> "]")
+    expected = [%Result{id: 14, document: @document},
+                %Result{id: 25, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "last child p" do
+    selector = xpath("//p[last()]")
+    expected = [%Result{id: 17, document: @document},
+                %Result{id: 25, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "second child p of div with id main" do
+    selector = xpath("//div[@id = 'main']/p[2]")
+    expected = [%Result{id: 14, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "every child node of a div" do
+    selector = xpath("//div/*")
+    expected = [%Result{id: 11, document: @document},
+                %Result{id: 14, document: @document},
+                %Result{id: 17, document: @document},
+                %Result{id: 20, document: @document},
+                %Result{id: 22, document: @document},
+                %Result{id: 25, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "every p node" do
+    selector = xpath("//p")
+    expected = [%Result{id: 11, document: @document},
+                %Result{id: 14, document: @document},
+                %Result{id: 17, document: @document},
+                %Result{id: 22, document: @document},
+                %Result{id: 25, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "every p text node" do
+    selector = xpath("/html//p/text()")
+    expected = [%Result{id: 12, document: @document},
+                %Result{id: 15, document: @document},
+                %Result{id: 18, document: @document},
+                %Result{id: 23, document: @document},
+                %Result{id: 26, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "following p siblings of #first-p" do
+    selector = xpath("//p[@id='first-p']/following-sibling::p")
+    expected = [%Result{id: 14, document: @document},
+                %Result{id: 17, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "first following p sibling of #first-p" do
+    selector = xpath("//p[@id='first-p']/following-sibling::p[1]")
+    expected = [%Result{id: 14, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "parent of the first following p sibling of #first-p" do
+    selector = xpath("//p[@id='first-p']/following-sibling::p[1]/..")
+    expected = [%Result{id: 9, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "has data-id attribute" do
+    selector = xpath("*[@data-id]")
+    expected = [%Result{id: 14, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "id is first-p" do
+    selector = xpath("//*[@id = 'first-p']")
+    expected = [%Result{id: 11, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "contains class b" do
+    selector = xpath("//*[contains(concat(' ', normalize-space(@class), ' '), ' b ')]")
+    expected = [%Result{id: 17, document: @document},
+                %Result{id: 25, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "div contains p with text equal to '2'" do
+    selector = xpath("div[p/text() = '2']")
+    expected = [%Result{id: 9, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "elements with a class attribute" do
+    selector = xpath("//*[@class]")
+    expected = [%Result{id: 17, document: @document},
+                %Result{id: 20, document: @document},
+                %Result{id: 25, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "element has text '5'" do
+    selector = xpath("//*[text() = '5']")
+    expected = [%Result{id: 25, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "elements has text > 2.5" do
+    selector = xpath("//*[text() > 2.5]")
+    expected = [%Result{id: 17, document: @document},
+                %Result{id: 22, document: @document},
+                %Result{id: 25, document: @document}]
+    assert Meeseeks.all(@document, selector) == expected
+  end
+
+  test "raise on invalid arguments" do
+    selector = xpath("//*[position(this) = 2]")
+    assert_raise RuntimeError, ~r/Invalid arguments to XPath function/, fn ->
+      Meeseeks.all(@document, selector)
+    end
+  end
+
+  test "raise on unknown function" do
+    selector = xpath("//*[unknown()]")
+    assert_raise RuntimeError, "XPath function unknown is unknown", fn ->
+      Meeseeks.all(@document, selector)
+    end
+  end
+
+  test "raise if attempting to use id()" do
+    selector = xpath("//*[id()]")
+    assert_raise RuntimeError, "XPath function id is unknown", fn ->
+      Meeseeks.all(@document, selector)
+    end
+  end
+
+  test "raise if attempting to use lang()" do
+    selector = xpath("//*[lang()]")
+    assert_raise RuntimeError, "XPath function lang is unknown", fn ->
+      Meeseeks.all(@document, selector)
+    end
+  end
+
+  test "raise if attempting to use translate()" do
+    selector = xpath("//*[translate()]")
+    assert_raise RuntimeError, "XPath function translate is unknown", fn ->
+      Meeseeks.all(@document, selector)
+    end
+  end
+end


### PR DESCRIPTION
An implementation of XPath 1.0 selectors for Meeseeks.

See the `Meeseeks.XPath` documentation and #9 for more details.

Includes a copy of the Apache2 License because `src/xpath_expression_parser.yrl`, is derived from an Apache2 licensed file (but relicensed under MIT). 