### PR TITLE
Add XML Parser (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Meeseeks is an Elixir library for parsing and extracting data from HTML.
 ```elixir
 import Meeseeks.CSS
 
-html = Tesla.get("https://news.ycombinator.com/").body
+html = HTTPoison.get!("https://news.ycombinator.com/").body
 
 for story <- Meeseeks.all(html, css("tr.athing")) do
   title = Meeseeks.one(story, css(".title a"))
@@ -44,14 +44,16 @@ This dependency is necessary because there are no HTML5 spec compliant parsers w
 
 ### Parse
 
-Start by parsing a source (HTML string or [`Meeseeks.TupleTree`](https://hexdocs.pm/meeseeks/Meeseeks.TupleTree.html)) into a [`Meeseeks.Document`](https://hexdocs.pm/meeseeks/Meeseeks.Document.html) so that it can be queried.
+Start by parsing a source (HTML/XML string or [`Meeseeks.TupleTree`](https://hexdocs.pm/meeseeks/Meeseeks.TupleTree.html)) into a [`Meeseeks.Document`](https://hexdocs.pm/meeseeks/Meeseeks.Document.html) so that it can be queried.
+
+`Meeseeks.parse/1` parses the source as HTML, but `Meeseeks.parse/2` accepts a second argument of either `:html` or `:xml` that specifies how the source is parsed.
 
 ```elixir
 document = Meeseeks.parse("<div id=main><p>1</p><p>2</p><p>3</p></div>")
 #=> #Meeseeks.Document<{...}>
 ```
 
-The selection functions accept an unparsed source, but parsing is expensive, so parse ahead of time when running multiple selections on the same document.
+The selection functions accept an unparsed source, parsing it as HTML, but parsing is expensive so parse ahead of time when running multiple selections on the same document.
 
 ### Select
 

--- a/lib/meeseeks/parser.ex
+++ b/lib/meeseeks/parser.ex
@@ -6,13 +6,14 @@ defmodule Meeseeks.Parser do
 
   @type source :: String.t | TupleTree.t
   @type error :: {:error, String.t}
+  @type type :: :html | :xml
 
   # Parse
 
   @spec parse(source) :: Document.t | error
 
-  def parse(html_string) when is_binary(html_string) do
-    case MeeseeksHtml5ever.parse(html_string) do
+  def parse(string) when is_binary(string) do
+    case MeeseeksHtml5ever.parse_html(string) do
       {:ok, document} -> document
       {:error, error} -> {:error, error}
     end
@@ -22,9 +23,30 @@ defmodule Meeseeks.Parser do
     parse_tuple_tree(tuple_tree)
   end
 
+  @spec parse(source, type) :: Document.t | error
+
+  def parse(string, :html) when is_binary(string) do
+    case MeeseeksHtml5ever.parse_html(string) do
+      {:ok, document} -> document
+      {:error, error} -> {:error, error}
+    end
+  end
+
+   def parse(string, :xml) when is_binary(string) do
+    case MeeseeksHtml5ever.parse_xml(string) do
+      {:ok, document} -> document
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  def parse(tuple_tree, _) do
+    parse_tuple_tree(tuple_tree)
+  end
+
   # Parse TupleTree
 
-  @spec parse_tuple_tree(TupleTree.t) :: Document.t
+  # Can't return error, only Document, just surpressing dialyzer error
+  @spec parse_tuple_tree(TupleTree.t) :: Document.t | error
 
   defp parse_tuple_tree(tuple_tree) when is_list(tuple_tree) do
     add_root_nodes(%Document{}, tuple_tree)

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Meeseeks.Mixfile do
   end
 
   defp deps do
-    [{:meeseeks_html5ever, "~> 0.5.0"},
+    [{:meeseeks_html5ever, "~> 0.6.0"},
 
      # dev
      {:credo, "~> 0.6.1", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -5,5 +5,5 @@
   "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "hoedown": {:git, "https://github.com/hoedown/hoedown.git", "980b9c549b4348d50b683ecee6abee470b98acda", []},
   "markdown": {:git, "https://github.com/devinus/markdown.git", "d065dbcc4e242a85ca2516fdadd0082712871fd8", []},
-  "meeseeks_html5ever": {:hex, :meeseeks_html5ever, "0.5.0", "746d714f1b9fa52e3130dd41f1f73174b77606a52a0a85a2247343041e98807b", [:mix], [{:rustler, "~> 0.9", [hex: :rustler, optional: false]}]},
+  "meeseeks_html5ever": {:hex, :meeseeks_html5ever, "0.6.0", "e33d948eed85f513aead012d3afce2370922f30f60767360a27eb25462ae5714", [:mix], [{:rustler, "~> 0.9", [hex: :rustler, optional: false]}]},
   "rustler": {:hex, :rustler, "0.9.0", "6fa87ac78f48f70aa8ecfb6e16b8af41c398989d33de41d292b5581d6a2eeb5a", [:mix], []}}

--- a/test/meeseeks/parse_test.exs
+++ b/test/meeseeks/parse_test.exs
@@ -4,6 +4,8 @@ defmodule Meeseeks.ParseTest do
   alias Meeseeks.Document
   alias Meeseeks.Parser
 
+  # HTML Parsing
+
   test "comment can exist at root" do
     document = Parser.parse("<!-- Hi --><html></html>")
     nodes = document.nodes |> Map.values()
@@ -11,7 +13,7 @@ defmodule Meeseeks.ParseTest do
   end
 
   test "comment can exist as child" do
-    document = Parser.parse("<div><!-- Hi --></div>")
+    document = Parser.parse("<div><!-- Hi --></div>", :html)
     nodes = document.nodes |> Map.values()
     assert Enum.any?(nodes, &comment_node?/1)
   end
@@ -23,7 +25,7 @@ defmodule Meeseeks.ParseTest do
   end
 
   test "doctype can exist at root" do
-    document = Parser.parse("<!DOCTYPE html><html></html>")
+    document = Parser.parse("<!DOCTYPE html><html></html>", :html)
     nodes = document.nodes |> Map.values()
     assert Enum.any?(nodes, &doctype_node?/1)
   end
@@ -35,7 +37,7 @@ defmodule Meeseeks.ParseTest do
   end
 
   test "element can exist at root" do
-    document = Parser.parse("<html></html>")
+    document = Parser.parse("<html></html>", :html)
     nodes = document.nodes |> Map.values()
     assert Enum.any?(nodes, &element_node?/1)
   end
@@ -52,6 +54,22 @@ defmodule Meeseeks.ParseTest do
     assert Enum.any?(nodes, &text_node?/1)
   end
 
+  # XML Parsing
+
+  test "cdata parses as text" do
+    document = Parser.parse("<node><![CDATA[Am Text]]></node>", :xml)
+    nodes = document.nodes |> Map.values()
+    assert Enum.any?(nodes, &text_node?/1)
+  end
+
+  test "processing instructions can exist" do
+    document = Parser.parse("<?xml-stylesheet type='text/xsl' href='style.xsl'?>", :xml)
+    nodes = document.nodes |> Map.values()
+    assert Enum.any?(nodes, &pi_node?/1)
+  end
+
+  # Helpers
+
   defp comment_node?(%Document.Comment{}), do: true
   defp comment_node?(_), do: false
 
@@ -63,6 +81,9 @@ defmodule Meeseeks.ParseTest do
 
   defp element_node?(%Document.Element{}), do: true
   defp element_node?(_), do: false
+
+  defp pi_node?(%Document.ProcessingInstruction{}), do: true
+  defp pi_node?(_), do: false
 
   defp text_node?(%Document.Text{}), do: true
   defp text_node?(_), do: false


### PR DESCRIPTION
Add XML parser as discussed in #12.

The XML parser can be used via the newly added `Meeseeks.parse/2`:

```elixir
Meeseeks.parse("<random>XML</random>", :xml)
``` 