### PR TITLE
Support Otp 20.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   include:
     - otp_release: 19.0
       elixir: 1.3.0
-    - otp_release: 20.0
+    - otp_release: 20.2
       elixir: 1.5.1
 
 sudo: false

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Meeseeks.Mixfile do
   end
 
   defp deps do
-    [{:meeseeks_html5ever, "~> 0.8.0"},
+    [{:meeseeks_html5ever, "~> 0.8.1"},
 
      # dev
      {:credo, "~> 0.6.1", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -5,5 +5,5 @@
   "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "hoedown": {:git, "https://github.com/hoedown/hoedown.git", "980b9c549b4348d50b683ecee6abee470b98acda", []},
   "markdown": {:git, "https://github.com/devinus/markdown.git", "d065dbcc4e242a85ca2516fdadd0082712871fd8", []},
-  "meeseeks_html5ever": {:hex, :meeseeks_html5ever, "0.8.0", "ac81ff0cf35206dbb9a9f31d7d67ecc566de8f4c380c5da3cdc5ac63b7bdbc8d", [:mix], [{:rustler, "~> 0.10.1", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm"},
-  "rustler": {:hex, :rustler, "0.10.1", "cedcce8b8960e5a8d528903891e8cc7f2f0306680a1c478455e3d8e572c65cc4", [:mix], [], "hexpm"}}
+  "meeseeks_html5ever": {:hex, :meeseeks_html5ever, "0.8.1", "8b10ad450d31b99408e570fab5f8e26aad9fa1cd2d6da0b99b5aa0a216809896", [:mix], [{:rustler, "~> 0.16", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm"},
+  "rustler": {:hex, :rustler, "0.16.0", "9b04237d2e7b30fcae40a28edb56f59aad8f4e3c8790f4996b5f200f649964be", [:mix], [], "hexpm"}}


### PR DESCRIPTION
Update to meeseeks_html5ever v0.8.1 (which supports OTP 20.2, resolving #30), and update .travis.yml to test OTP 20.2.