### PR TITLE
Fixed dialyzer warnings, uncovered possible bug in get_nodes/2

### DIFF
--- a/lib/meeseeks/document.ex
+++ b/lib/meeseeks/document.ex
@@ -288,12 +288,12 @@ defmodule Meeseeks.Document do
 
   Raises if any id in node_ids does not exist in the document.
   """
-  @spec get_nodes(Document.t(), [node_id]) :: [node_t]
-  def get_nodes(%Document{nodes: nodes}, node_ids) do
+  @spec get_nodes(Document.t(), [node_id]) :: [node_t] | no_return
+  def get_nodes(document, node_ids) do
     Enum.map(node_ids, fn node_id ->
-      case Map.fetch(nodes, node_id) do
+      case fetch_node(document, node_id) do
         {:ok, node} -> node
-        {:error, %Error{} = error} -> raise error
+        {:error, error} -> raise error
       end
     end)
   end
@@ -301,7 +301,7 @@ defmodule Meeseeks.Document do
   @doc """
   Returns a tuple of {:ok, node}, where node is the node referred to by node_id in the context of the document, or :error.
   """
-  @spec fetch_node(Document.t(), node_id) :: {:ok, node} :: {:error, Error.t()}
+  @spec fetch_node(Document.t(), node_id) :: {:ok, node_t} | {:error, Error.t()}
   def fetch_node(%Document{nodes: nodes} = document, node_id) do
     case Map.fetch(nodes, node_id) do
       {:ok, _} = ok ->

--- a/lib/meeseeks/selector/combinator.ex
+++ b/lib/meeseeks/selector/combinator.ex
@@ -52,6 +52,7 @@ defmodule Meeseeks.Selector.Combinator do
               [Document.node_t()]
               | Document.node_t()
               | nil
+              | no_return
 
   @doc """
   Invoked to return the combinator's selector.
@@ -66,7 +67,8 @@ defmodule Meeseeks.Selector.Combinator do
   Returns the applicable node or nodes, or `nil` if there are no applicable
   nodes.
   """
-  @spec next(t, Document.node_t(), Document.t()) :: [Document.node_t()] | Document.node_t() | nil
+  @spec next(t, Document.node_t(), Document.t()) ::
+          [Document.node_t()] | Document.node_t() | nil | no_return
   def next(%{__struct__: struct} = combinator, node, document) do
     struct.next(combinator, node, document)
   end


### PR DESCRIPTION
This fixed 70+ dialyzer warnings in the project for me.

Only noise left is from yecc and xmerl not being a dependency (since it seems to be a compile-time dependency only). Adding it to extra_applications in `mix.exs` fixes it, but I don' t know if that should be done or not.