### PR TITLE
Support Elixir 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,20 @@ matrix:
   include:
     - otp_release: 19.0
       elixir: 1.3.0
+    - otp_release: 19.3
+      elixir: 1.4.0
+    - otp_release: 20.0
+      elixir: 1.4.5
+    - otp_release: 20.0
+      elixir: 1.5.1
+    - otp_release: 20.2
+      elixir: 1.5.1
+    - otp_release: 20.2
+      elixir: 1.6.3
     - otp_release: 21.0
       elixir: 1.6.6
+    - otp_release: 21.0
+      elixir: 1.7.3
 
 sudo: false
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Meeseeks.Mixfile do
 
   defp deps do
     [
-      {:meeseeks_html5ever, "~> 0.10.0"},
+      {:meeseeks_html5ever, "~> 0.10.1"},
 
       # dev
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -6,6 +6,6 @@
   "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "hoedown": {:git, "https://github.com/hoedown/hoedown.git", "980b9c549b4348d50b683ecee6abee470b98acda", []},
   "markdown": {:git, "https://github.com/devinus/markdown.git", "d065dbcc4e242a85ca2516fdadd0082712871fd8", []},
-  "meeseeks_html5ever": {:hex, :meeseeks_html5ever, "0.10.0", "3cac0c19800f0e2987c69b5c6b2a8dd62e171c606dc301aa4b3f686b79894ba4", [:mix], [{:rustler, "~> 0.18.0", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm"},
+  "meeseeks_html5ever": {:hex, :meeseeks_html5ever, "0.10.1", "3ea11440b91dc61751dd05dd6bbfd23110f7a2116338f42b6835e8a07e1522cc", [:mix], [{:rustler, "~> 0.18.0", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm"},
   "rustler": {:hex, :rustler, "0.18.0", "db4bd0c613d83a1badc31be90ddada6f9821de29e4afd15c53a5da61882e4f2d", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
Update to meeseeks_html5ever `v0.10.0 `and update `.travis.yml` to include Elixir 1.7, as well as previous versions.