### PR TITLE
Improve tuple tree parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Finally, run `mix deps.get`.
 
 Start by parsing a source (HTML/XML string or [`Meeseeks.TupleTree`](https://hexdocs.pm/meeseeks/Meeseeks.TupleTree.html)) into a [`Meeseeks.Document`](https://hexdocs.pm/meeseeks/Meeseeks.Document.html) so that it can be queried.
 
-`Meeseeks.parse/1` parses the source as HTML, but `Meeseeks.parse/2` accepts a second argument of either `:html` or `:xml` that specifies how the source is parsed.
+`Meeseeks.parse/1` parses the source as HTML, but `Meeseeks.parse/2` accepts a second argument of either `:html`, `:xml`, or `:tuple_tree` that specifies how the source is parsed.
 
 ```elixir
 document = Meeseeks.parse("<div id=main><p>1</p><p>2</p><p>3</p></div>")

--- a/lib/meeseeks.ex
+++ b/lib/meeseeks.ex
@@ -239,17 +239,18 @@ defmodule Meeseeks do
   Parses a string or `Meeseeks.TupleTree` into a `Meeseeks.Document`.
 
   `parse/1` parses as HTML, while `parse/2` accepts a second argument of
-  either `:html` or `:xml` that specifies how the source is parsed.
+  either `:html`, `:xml`, or `tuple_tree` that specifies how the source is
+  parsed.
 
   ## Examples
 
       iex> Meeseeks.parse("<div id=main><p>Hello, Meeseeks!</p></div>")
       #Meeseeks.Document<{...}>
 
-      iex> Meeseeks.parse({"div", [{"id", "main"}], [{"p", [], ["Hello, Meeseeks!"]}]})
+      iex> Meeseeks.parse("<book><author>GGK</author></book>", :xml)
       #Meeseeks.Document<{...}>
 
-      iex> Meeseeks.parse("<book><author>GGK</author></book>", :xml)
+      iex> Meeseeks.parse({"div", [{"id", "main"}], [{"p", [], ["Hello, Meeseeks!"]}]}, :tuple_tree)
       #Meeseeks.Document<{...}>
   """
   @spec parse(Parser.source()) :: Document.t() | {:error, Error.t()}

--- a/lib/meeseeks/parser.ex
+++ b/lib/meeseeks/parser.ex
@@ -5,7 +5,7 @@ defmodule Meeseeks.Parser do
   alias Meeseeks.Document.{Comment, Data, Doctype, Element, ProcessingInstruction, Text}
 
   @type source :: String.t() | TupleTree.t()
-  @type type :: :html | :xml
+  @type type :: :html | :xml | :tuple_tree
 
   # Parse
 
@@ -26,7 +26,12 @@ defmodule Meeseeks.Parser do
   end
 
   def parse(tuple_tree) do
-    parse_tuple_tree(tuple_tree)
+    IO.warn(
+      "parse/1 with a tuple tree is deprecated. " <>
+        "Please use parse/2 with the :tuple_tree type instead."
+    )
+
+    parse(tuple_tree, :tuple_tree)
   end
 
   @spec parse(source, type) :: Document.t() | {:error, Error.t()}
@@ -45,7 +50,7 @@ defmodule Meeseeks.Parser do
     end
   end
 
-  def parse(tuple_tree, _) do
+  def parse(tuple_tree, :tuple_tree) when is_list(tuple_tree) or is_tuple(tuple_tree) do
     parse_tuple_tree(tuple_tree)
   end
 

--- a/test/meeseeks/document_test.exs
+++ b/test/meeseeks/document_test.exs
@@ -20,7 +20,7 @@ defmodule Meeseeks.DocumentTest do
         ]}
      ]}
   ]
-  @document Meeseeks.Parser.parse(@tree)
+  @document Meeseeks.Parser.parse(@tree, :tuple_tree)
 
   test "html" do
     expected =

--- a/test/meeseeks/parser/tuple_tree_test.exs
+++ b/test/meeseeks/parser/tuple_tree_test.exs
@@ -1,7 +1,7 @@
 defmodule Meeseeks.Parser.TupleTreeTest do
   use ExUnit.Case
 
-  alias Meeseeks.Parser
+  alias Meeseeks.{Error, Parser}
 
   @tuple_tree [
     {:doctype, "html", "", ""},
@@ -25,5 +25,23 @@ defmodule Meeseeks.Parser.TupleTreeTest do
 
   test "tuple tree parser makes same document as string parser" do
     assert Parser.parse(@tuple_tree) == Parser.parse(@string)
+  end
+
+  @invalid_tuple_tree_root_node {:ok, {"html", [], []}}
+
+  test "tuple tree parser can't parse invalid root nodes" do
+    {:error, %Error{} = error} = Parser.parse(@invalid_tuple_tree_root_node)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree root node"
+  end
+
+  @invalid_tuple_tree_node {"h1", [], [{:error, "NotANode"}]}
+
+  test "tuple tree parser can't parse invalid nodes" do
+    {:error, %Error{} = error} = Parser.parse(@invalid_tuple_tree_node)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree node"
   end
 end

--- a/test/meeseeks/parser/tuple_tree_test.exs
+++ b/test/meeseeks/parser/tuple_tree_test.exs
@@ -24,13 +24,13 @@ defmodule Meeseeks.Parser.TupleTreeTest do
   @string "<!DOCTYPE html><html><head></head><body><div><p></p><p></p><div><p></p><p></p></div><p></p></div></body></html>"
 
   test "tuple tree parser makes same document as string parser" do
-    assert Parser.parse(@tuple_tree) == Parser.parse(@string)
+    assert Parser.parse(@tuple_tree, :tuple_tree) == Parser.parse(@string)
   end
 
   @invalid_tuple_tree_root_node {:ok, {"html", [], []}}
 
   test "tuple tree parser can't parse invalid root nodes" do
-    {:error, %Error{} = error} = Parser.parse(@invalid_tuple_tree_root_node)
+    {:error, %Error{} = error} = Parser.parse(@invalid_tuple_tree_root_node, :tuple_tree)
     assert error.type == :parser
     assert error.reason == :invalid_input
     assert error.metadata.description == "invalid tuple tree root node"
@@ -39,7 +39,7 @@ defmodule Meeseeks.Parser.TupleTreeTest do
   @invalid_tuple_tree_node {"h1", [], [{:error, "NotANode"}]}
 
   test "tuple tree parser can't parse invalid nodes" do
-    {:error, %Error{} = error} = Parser.parse(@invalid_tuple_tree_node)
+    {:error, %Error{} = error} = Parser.parse(@invalid_tuple_tree_node, :tuple_tree)
     assert error.type == :parser
     assert error.reason == :invalid_input
     assert error.metadata.description == "invalid tuple tree node"

--- a/test/meeseeks/selector/combinators_test.exs
+++ b/test/meeseeks/selector/combinators_test.exs
@@ -18,7 +18,8 @@ defmodule Meeseeks.Selector.CombinatorsTest do
                        {"p", [], ["5"]}
                      ]}
                   ]}
-               ]}
+               ]},
+              :tuple_tree
             )
 
   test "parent" do

--- a/test/meeseeks/selector/xpath/combinators_test.exs
+++ b/test/meeseeks/selector/xpath/combinators_test.exs
@@ -5,7 +5,7 @@ defmodule Meeseeks.Selector.XPath.CombinatorsTest do
   alias Meeseeks.Selector.{Combinator, XPath}
 
   @attributes [{"id", "unique"}, {"class", "a couple"}]
-  @document Meeseeks.Parser.parse({"awesome:div", @attributes, []})
+  @document Meeseeks.Parser.parse({"awesome:div", @attributes, []}, :tuple_tree)
 
   test "attributes" do
     combinator = %XPath.Combinator.Attributes{}

--- a/test/meeseeks/selector/xpath/expr/arithmetic_test.exs
+++ b/test/meeseeks/selector/xpath/expr/arithmetic_test.exs
@@ -6,7 +6,8 @@ defmodule Meeseeks.Selector.XPath.Expr.ArithmeticTest do
   alias Meeseeks.Selector.XPath.Expr
 
   @document Meeseeks.parse(
-              {"book", [], [{"chapter", [], [{"page", [], ["1"]}, {"page", [], ["2"]}]}]}
+              {"book", [], [{"chapter", [], [{"page", [], ["1"]}, {"page", [], ["2"]}]}]},
+              :tuple_tree
             )
 
   test "add" do

--- a/test/meeseeks/selector/xpath/expr/boolean_test.exs
+++ b/test/meeseeks/selector/xpath/expr/boolean_test.exs
@@ -6,7 +6,8 @@ defmodule Meeseeks.Selector.XPath.Expr.BooleanTest do
   alias Meeseeks.Selector.XPath.Expr
 
   @document Meeseeks.parse(
-              {"book", [], [{"chapter", [], [{"page", [], ["1"]}, {"page", [], ["2"]}]}]}
+              {"book", [], [{"chapter", [], [{"page", [], ["1"]}, {"page", [], ["2"]}]}]},
+              :tuple_tree
             )
 
   test "true or true" do

--- a/test/meeseeks/selector/xpath/expr/comparative_test.exs
+++ b/test/meeseeks/selector/xpath/expr/comparative_test.exs
@@ -6,7 +6,8 @@ defmodule Meeseeks.Selector.XPath.Expr.ComparativeTest do
   alias Meeseeks.Selector.XPath.Expr
 
   @document Meeseeks.parse(
-              {"book", [], [{"chapter", [], [{"page", [], ["1"]}, {"page", [], ["2"]}]}]}
+              {"book", [], [{"chapter", [], [{"page", [], ["1"]}, {"page", [], ["2"]}]}]},
+              :tuple_tree
             )
 
   test "equal" do

--- a/test/meeseeks/selector/xpath/expr/function_test.exs
+++ b/test/meeseeks/selector/xpath/expr/function_test.exs
@@ -20,7 +20,8 @@ defmodule Meeseeks.Selector.XPath.Expr.FunctionTest do
                        {"p", [], ["5"]}
                      ]}
                   ]}
-               ]}
+               ]},
+              :tuple_tree
             )
 
   # last

--- a/test/meeseeks/selector/xpath/expr/negative_test.exs
+++ b/test/meeseeks/selector/xpath/expr/negative_test.exs
@@ -5,7 +5,8 @@ defmodule Meeseeks.Selector.XPath.Expr.NegativeTest do
   alias Meeseeks.Selector.XPath.Expr
 
   @document Meeseeks.parse(
-              {"book", [], [{"chapter", [], [{"page", [], ["1"]}, {"page", [], ["2"]}]}]}
+              {"book", [], [{"chapter", [], [{"page", [], ["1"]}, {"page", [], ["2"]}]}]},
+              :tuple_tree
             )
 
   test "negate positive" do

--- a/test/meeseeks/selector/xpath/expr/path_test.exs
+++ b/test/meeseeks/selector/xpath/expr/path_test.exs
@@ -6,7 +6,8 @@ defmodule Meeseeks.Selector.XPath.Expr.PathTest do
   alias Meeseeks.Selector.XPath.Expr
 
   @document Meeseeks.parse(
-              {"book", [], [{"chapter", [], [{"page", [], ["1"]}, {"page", [], ["2"]}]}]}
+              {"book", [], [{"chapter", [], [{"page", [], ["1"]}, {"page", [], ["2"]}]}]},
+              :tuple_tree
             )
 
   test "absolute path" do

--- a/test/meeseeks/selector/xpath/expr/step_test.exs
+++ b/test/meeseeks/selector/xpath/expr/step_test.exs
@@ -6,7 +6,8 @@ defmodule Meeseeks.Selector.XPath.Expr.StepTest do
   alias Meeseeks.Selector.XPath.Expr
 
   @document Meeseeks.parse(
-              {"book", [], [{"chapter", [], [{"page", [], ["1"]}, {"page", [], ["2"]}]}]}
+              {"book", [], [{"chapter", [], [{"page", [], ["1"]}, {"page", [], ["2"]}]}]},
+              :tuple_tree
             )
 
   test "step no matches" do

--- a/test/meeseeks/selector/xpath/expr/union_test.exs
+++ b/test/meeseeks/selector/xpath/expr/union_test.exs
@@ -6,7 +6,8 @@ defmodule Meeseeks.Selector.XPath.Expr.UnionTest do
   alias Meeseeks.Selector.XPath.Expr
 
   @document Meeseeks.parse(
-              {"book", [], [{"chapter", [], [{"page", [], ["1"]}, {"page", [], ["2"]}]}]}
+              {"book", [], [{"chapter", [], [{"page", [], ["1"]}, {"page", [], ["2"]}]}]},
+              :tuple_tree
             )
 
   test "union both match" do


### PR DESCRIPTION
PR for issue #55.

- Returns parser error if parsing an invalid tuple tree
- Add `:tuple_tree` type to `parse/2`
- Deprecate parsing tuple trees with `parse/1`