### PR TITLE
Support more characters in CSS selector strings

### DIFF
--- a/src/css_selector_tokenizer.xrl
+++ b/src/css_selector_tokenizer.xrl
@@ -1,15 +1,18 @@
 Definitions.
 
-NMSTART = [A-Za-z_]
-NMCHAR = [-A-Za-z0-9_]
+NONASCII = [^\x00-\x7F]
+ESCAPE = \\[^\r\n\f]
+NMSTART = ([_A-Za-z]|{NONASCII}|{ESCAPE})
+NMCHAR = ([_A-Za-z0-9-]|{NONASCII}|{ESCAPE})
 NL = \n|\r\n|\r|\f
-STRING1 = \"([\t\s\!\#\$\%&\(-~]|\\{NL}\|\')*\"
-STRING2 = \'([\t\s\!\#\$\%&\(-~]|\\{NL}\|\")*\'
+STRING1 = \"([^\n\r\f\\"]|\\{NL}|{ESCAPE})*\"
+STRING2 = \'([^\n\r\f\\']|\\{NL}|{ESCAPE})*\'
 IDENT = (\-)?{NMSTART}{NMCHAR}*
 NAME = {NMCHAR}+
 INT = [0-9]+
 STRING = {STRING1}|{STRING2}
-W = [\s\t\r\n\f]*
+S = [\s\t\r\n\f]+
+W = {S}?
 AB_FORMULA = ([\+\-]{W})?{INT}?[nN]({W}[\+\-]{W}{INT})?
 
 Rules.
@@ -25,15 +28,15 @@ Rules.
 \*= : {token, value_contains}.
 = : {token, value}.
 
-{IDENT}\({W} : {token, {function, trim_and_drop_last(TokenChars)}}.
+{IDENT}\({W} : {token, {function, without_escapes(trim_and_drop_last(TokenChars))}}.
 {AB_FORMULA} : {token, {ab_formula, TokenChars}}.
 \+{INT} : {token, {int, drop_first(TokenChars)}}.
 {INT} : {token, {int, TokenChars}}.
-{STRING} : {token, {string, remove_quotes(TokenChars)}}.
-{IDENT} : {token, {ident, TokenChars}}.
+{STRING} : {token, {string, without_escapes(remove_quotes(TokenChars))}}.
+{IDENT} : {token, {ident, without_escapes(TokenChars)}}.
 
-\.{IDENT} : {token, {class, drop_first(TokenChars)}}.
-#{NAME} : {token, {id, drop_first(TokenChars)}}.
+\.{IDENT} : {token, {class, without_escapes(drop_first(TokenChars))}}.
+#{NAME} : {token, {id, without_escapes(drop_first(TokenChars))}}.
 
 
 \:{W} : {token, ":"}.
@@ -61,3 +64,6 @@ trim_and_drop_last(Chars) ->
 remove_quotes(Chars) ->
     Len = string:len(Chars),
     string:substr(Chars, 2, Len - 2).
+
+without_escapes(Chars) ->
+    re:replace(Chars, "\\\\", "", [unicode, global, {return, list}]).

--- a/test/meeseeks/selector/css/tokenizer_test.exs
+++ b/test/meeseeks/selector/css/tokenizer_test.exs
@@ -28,9 +28,33 @@ defmodule Meeseeks.Selector.CSS.TokenizerTest do
     assert Tokenizer.tokenize(selector) == tokens
   end
 
+  test "start with escaped class" do
+    selector = ".\\123"
+    tokens = [class: '123']
+    assert Tokenizer.tokenize(selector) == tokens
+  end
+
+  test "start with unicode class" do
+    selector = ".❤"
+    tokens = [class: [?❤]]
+    assert Tokenizer.tokenize(selector) == tokens
+  end
+
   test "start with id" do
     selector = "#id.class"
     tokens = [{:id, 'id'}, {:class, 'class'}]
+    assert Tokenizer.tokenize(selector) == tokens
+  end
+
+  test "start with escaped id" do
+    selector = "#\\123"
+    tokens = [id: '123']
+    assert Tokenizer.tokenize(selector) == tokens
+  end
+
+  test "start with unicode id" do
+    selector = "#❤"
+    tokens = [id: [?❤]]
     assert Tokenizer.tokenize(selector) == tokens
   end
 
@@ -102,6 +126,24 @@ defmodule Meeseeks.Selector.CSS.TokenizerTest do
   test "attribute equals" do
     selector = "tag[attr=value]"
     tokens = [{:ident, 'tag'}, '[', {:ident, 'attr'}, :value, {:ident, 'value'}, ']']
+    assert Tokenizer.tokenize(selector) == tokens
+  end
+
+  test "attribute equals string" do
+    selector = "tag[attr=\"value\"]"
+    tokens = [{:ident, 'tag'}, '[', {:ident, 'attr'}, :value, {:string, 'value'}, ']']
+    assert Tokenizer.tokenize(selector) == tokens
+  end
+
+  test "attribute equals string with escaped" do
+    selector = "tag[attr=\"\\~\\~\\~\"]"
+    tokens = [{:ident, 'tag'}, '[', {:ident, 'attr'}, :value, {:string, '~~~'}, ']']
+    assert Tokenizer.tokenize(selector) == tokens
+  end
+
+  test "attribute equals string with unicode" do
+    selector = "tag[attr=\"❤\"]"
+    tokens = [{:ident, 'tag'}, '[', {:ident, 'attr'}, :value, {:string, [?❤]}, ']']
     assert Tokenizer.tokenize(selector) == tokens
   end
 


### PR DESCRIPTION
PR for issue #58. 

- Support escaped characters in CSS selector names, idents, and strings
- Support Elixir-style unicode code points in CSS selector names, idents, and strings (but not hexadecimal code points)

```elixir
iex(1)> import Meeseeks.CSS
Meeseeks.CSS

iex(2)> Meeseeks.one("<div id=\"~\"></div>", css("#\\~"))
#Meeseeks.Result<{ <div id="~"></div> }>

iex(3)> Meeseeks.one("<div class=\"❤\"></div>", css(".❤"))  
#Meeseeks.Result<{ <div class="❤"></div> }>
```