### PR TITLE
Release v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.11.2 (2019-07-21)
+
+### Fixes
+
+  * [Select] Support escaped characters in CSS selector names, idents, and strings
+  * [Select] Support Elixir-style unicode code points in CSS selector names, idents, and strings
+  * [Select] Add better errors when parsing CSS selectors
+
 ## v0.11.1 (2019-06-28)
 
 ### Deprecations

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Ensure Rust is installed, then add Meeseeks to your `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:meeseeks, "~> 0.11.1"}
+    {:meeseeks, "~> 0.11.2"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meeseeks.Mixfile do
   use Mix.Project
 
-  @version "0.11.1"
+  @version "0.11.2"
 
   def project do
     [


### PR DESCRIPTION
### Fixes

  * [Select] Support escaped characters in CSS selector names, idents, and strings
  * [Select] Support Elixir-style unicode code points in CSS selector names, idents, and strings
  * [Select] Add better errors when parsing CSS selectors