### PR TITLE
Escape problem chars when encoding attribute values and text to html

### DIFF
--- a/lib/meeseeks/document/element.ex
+++ b/lib/meeseeks/document/element.ex
@@ -129,11 +129,7 @@ defmodule Meeseeks.Document.Element do
   end
 
   defp join_attribute({attribute, value}, acc) do
-    if String.contains?(value, "\"") do
-      "#{acc} #{attribute}='#{value}'"
-    else
-      "#{acc} #{attribute}=\"#{value}\""
-    end
+    "#{acc} #{attribute}=\"#{Helpers.html_escape_attribute_value(value)}\""
   end
 
   defp join_data(node, acc, document) do

--- a/lib/meeseeks/document/helpers.ex
+++ b/lib/meeseeks/document/helpers.ex
@@ -1,7 +1,43 @@
 defmodule Meeseeks.Document.Helpers do
   @moduledoc false
 
+  # collapse_whitespace
+
   def collapse_whitespace(string) do
     String.replace(string, ~r/[\s]+/, " ")
   end
+
+  # html_escape
+
+  def html_escape_attribute_value(attribute_value) do
+    html_escape_chars(attribute_value, ["&", "\""])
+  end
+
+  def html_escape_text(text) do
+    html_escape_chars(text, ["&", "<", ">"])
+  end
+
+  defp html_escape_chars(subject, escaped_chars) do
+    matches = :binary.matches(subject, escaped_chars)
+
+    subject
+    |> do_replace(matches, &html_escape_char/1, 0)
+    |> IO.iodata_to_binary()
+  end
+
+  defp do_replace(subject, [], _, n) do
+    [binary_part(subject, n, byte_size(subject) - n)]
+  end
+
+  defp do_replace(subject, [{start, length} | matches], replacement, n) do
+    prefix = binary_part(subject, n, start - n)
+    middle = replacement.(binary_part(subject, start, length))
+    [prefix, middle | do_replace(subject, matches, replacement, start + length)]
+  end
+
+  defp html_escape_char("<"), do: "&lt;"
+  defp html_escape_char(">"), do: "&gt;"
+  defp html_escape_char("&"), do: "&amp;"
+  defp html_escape_char("\""), do: "&quot;"
+  defp html_escape_char("'"), do: "&#39;"
 end

--- a/lib/meeseeks/document/text.ex
+++ b/lib/meeseeks/document/text.ex
@@ -9,7 +9,7 @@ defmodule Meeseeks.Document.Text do
 
   @impl true
   def html(node, _document) do
-    node.content
+    Helpers.html_escape_text(node.content)
   end
 
   @impl true

--- a/test/meeseeks/document_test.exs
+++ b/test/meeseeks/document_test.exs
@@ -10,7 +10,7 @@ defmodule Meeseeks.DocumentTest do
        {"head", [], []},
        {"body", [],
         [
-          {"div", [{"attr", "1 \"2\" 3"}],
+          {"div", [{"attr", "1 \"2\" 3 '"}],
            [
              {"p", [], []},
              {"p", [], []},
@@ -24,7 +24,7 @@ defmodule Meeseeks.DocumentTest do
 
   test "html" do
     expected =
-      "<!DOCTYPE html><html><head></head><body><div attr='1 \"2\" 3'><p></p><p></p><div><p></p><p></p></div><p></p></div></body></html>"
+      "<!DOCTYPE html><html><head></head><body><div attr=\"1 &quot;2&quot; 3 '\"><p></p><p></p><div><p></p><p></p></div><p></p></div></body></html>"
 
     assert Document.html(@document) == expected
   end


### PR DESCRIPTION
PR for issue #62. 

**Warning: this is arguably a breaking change since the output of `Meeseeks.html/1` can be different from output for the same input on previous versions**

- When encoding attribute values with `Meeseeks.html/1` always double quote and escape `&` and `"`
- When encoding text with `Meeseeks.html/1` escape `<`, `>`, and `&`