### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.12.0 (2019-07-25)
+
+### Breaking
+
+  * [Extract] `Meeseeks.html/1` now escapes problematic characters when encoding attribute values and text, so its output may be slightly different than before
+
+### Fixes
+
+  * [Extract] Always use double quotes and escape `&` and `"` when encoding attribute values with `Meeseeks.html/1`
+  * [Extract] Escape `<`, `>`, and `&` when encoding text with `Meeseeks.html/1`
+
 ## v0.11.2 (2019-07-21)
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Ensure Rust is installed, then add Meeseeks to your `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:meeseeks, "~> 0.11.2"}
+    {:meeseeks, "~> 0.12.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meeseeks.Mixfile do
   use Mix.Project
 
-  @version "0.11.2"
+  @version "0.12.0"
 
   def project do
     [


### PR DESCRIPTION
### Breaking

* [Extract] `Meeseeks.html/1` now escapes problematic characters when encoding attribute values and text, so its output may be slightly different than before

### Fixes

* [Extract] Always use double quotes and escape `&` and `"` when encoding attribute values with `Meeseeks.html/1`
* [Extract] Escape `<`, `>`, and `&` when encoding text with `Meeseeks.html/1`