### PR TITLE
Support OTP 22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,18 @@ language: elixir
 
 matrix:
   include:
-    - otp_release: 19.3
-      elixir: 1.4.0
     - otp_release: 20.0
-      elixir: 1.4.5
+      elixir: 1.6.0
     - otp_release: 20.0
-      elixir: 1.5.1
-    - otp_release: 20.2
-      elixir: 1.6.3
+      elixir: 1.9.0
     - otp_release: 21.0
       elixir: 1.6.6
     - otp_release: 21.0
-      elixir: 1.7.3
-    - otp_release: 21.0
-      elixir: 1.8.1
+      elixir: 1.9.0
+    - otp_release: 22.0
+      elixir: 1.7.0
+    - otp_release: 22.0
+      elixir: 1.9.0
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For details and benchmarks, see [Meeseeks vs. Floki Performance](https://github.
 
 ## Compatibility
 
-Meeseeks is tested with a minimum combination of Elixir 1.4.0 and Erlang/OTP 19.3, and a maximum combination of Elixir 1.8.1 and Erlang/OTP 21.0.
+Meeseeks is tested with a minimum combination of Elixir 1.6.0 and Erlang/OTP 20, and a maximum combination of Elixir 1.9.0 and Erlang/OTP 22.0.
 
 ## Dependencies
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Meeseeks.Mixfile do
     [
       app: :meeseeks,
       version: @version,
-      elixir: "~> 1.4",
+      elixir: "~> 1.6",
       deps: deps(),
 
       # Hex
@@ -27,7 +27,7 @@ defmodule Meeseeks.Mixfile do
 
   defp deps do
     [
-      {:meeseeks_html5ever, "~> 0.11.1"},
+      {:meeseeks_html5ever, "~> 0.12.0"},
 
       # dev
       {:dialyxir, "~> 0.5", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -8,7 +8,8 @@
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "markdown": {:git, "https://github.com/devinus/markdown.git", "d065dbcc4e242a85ca2516fdadd0082712871fd8", []},
-  "meeseeks_html5ever": {:hex, :meeseeks_html5ever, "0.11.1", "aa2cd25021e055e0bd206beae73660cc198a6c90a3a6eca1aee8e8d7c48307b7", [:mix], [{:rustler, "~> 0.20.0", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm"},
+  "meeseeks_html5ever": {:hex, :meeseeks_html5ever, "0.12.0", "f915d91a8dea0d6f8d0c4bf89c93a6df7bd733ec7da5bb8b6e7b77d9f5431e7a", [:mix], [{:rustler, "~> 0.21.0", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
-  "rustler": {:hex, :rustler, "0.20.0", "6b2cc8149700a7b1df2226dbe273ec1f9449318cad3bd3b5b68125a4cf1f438b", [:mix], [], "hexpm"},
+  "rustler": {:hex, :rustler, "0.21.0", "68cc4fc015d0b9541865ea78e78e9ef2dd91ee4be80bf543fd15791102a45aca", [:mix], [{:toml, "~> 0.5.2", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm"},
+  "toml": {:hex, :toml, "0.5.2", "e471388a8726d1ce51a6b32f864b8228a1eb8edc907a0edf2bb50eab9321b526", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
Elixir 1.4, Elixir 1.5, and OTP 19 are no longer supported (Rustler now required a minimum version of 1.6).

Minimum tested combination is now Elixir 1.6.0 and OTP 20.0, and the maximum tested combination is Elixir 1.9.0 and OTP 22.0.

- Update Meeseeks_Html5ever to 0.12.0, which supports OTP 22
- Remove Elixir 1.4, Elixir 1.5, and OTP 19 from .travis.yml
- Add Elixir 1.9 and OTP 22 to .travis.yml