### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.13.0 (2019-09-08)
+
+### Compatability
+
+  * No longer support Elixir 1.4, Elixir 1.5, or Erlang/OTP 19 (minumum tested compatiblity is now Elixir 1.6 and Erlang/OTP 20)
+  * Support Elixir 1.9 and Erlang/OTP 22
+
+### Fixes
+
+  * [Parse] Update to `meeseeks_html5ever v0.12.0`, which supports Erlang/OTP 22
+
 ## v0.12.0 (2019-07-25)
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Ensure Rust is installed, then add Meeseeks to your `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:meeseeks, "~> 0.12.0"}
+    {:meeseeks, "~> 0.13.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meeseeks.Mixfile do
   use Mix.Project
 
-  @version "0.12.0"
+  @version "0.13.0"
 
   def project do
     [


### PR DESCRIPTION
### Compatability

  * No longer support Elixir 1.4, Elixir 1.5, or Erlang/OTP 19 (minumum tested compatiblity is now Elixir 1.6 and Erlang/OTP 20)
  * Support Elixir 1.9 and Erlang/OTP 22

### Fixes

  * [Parse] Update to `meeseeks_html5ever v0.12.0`, which supports Erlang/OTP 22