### PR TITLE
Update Meeseeks_Html5ever to 0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For details and benchmarks, see [Meeseeks vs. Floki Performance](https://github.
 
 ## Compatibility
 
-Meeseeks is tested with a minimum combination of Elixir 1.6.0 and Erlang/OTP 20, and a maximum combination of Elixir 1.9.0 and Erlang/OTP 22.0.
+Meeseeks requires a minimum combination of Elixir 1.6.0 and Erlang/OTP 20, and has been tested with a maximum combination of Elixir 1.9.0 and Erlang/OTP 22.0.
 
 ## Dependencies
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Meeseeks.Mixfile do
 
   defp deps do
     [
-      {:meeseeks_html5ever, "~> 0.12.0"},
+      {:meeseeks_html5ever, "~> 0.12.1"},
 
       # dev
       {:dialyxir, "~> 0.5", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -8,7 +8,7 @@
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "markdown": {:git, "https://github.com/devinus/markdown.git", "d065dbcc4e242a85ca2516fdadd0082712871fd8", []},
-  "meeseeks_html5ever": {:hex, :meeseeks_html5ever, "0.12.0", "f915d91a8dea0d6f8d0c4bf89c93a6df7bd733ec7da5bb8b6e7b77d9f5431e7a", [:mix], [{:rustler, "~> 0.21.0", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm"},
+  "meeseeks_html5ever": {:hex, :meeseeks_html5ever, "0.12.1", "718fab10d05b83204524a518b2b88caa37ba6a6e02f82e80d6a7bc47552fb54a", [:mix], [{:rustler, "~> 0.21.0", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "rustler": {:hex, :rustler, "0.21.0", "68cc4fc015d0b9541865ea78e78e9ef2dd91ee4be80bf543fd15791102a45aca", [:mix], [{:toml, "~> 0.5.2", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm"},
   "toml": {:hex, :toml, "0.5.2", "e471388a8726d1ce51a6b32f864b8228a1eb8edc907a0edf2bb50eab9321b526", [:mix], [], "hexpm"},


### PR DESCRIPTION
The latest version of `meeseeks_html5ever` uses a dirty scheduler for the NIF instead of working asynchronously, which became an option now that the minimum supported version of Erlang/OTP is 20.

Using the dirty scheduler permitted the NIF to be simplified and may speed things up.