### PR TITLE
Release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.13.1 (2019-09-09)
+
+### Enhancements
+
+  * [Parse] Update to `meeseeks_html5ever v0.12.1`, which uses a dirty scheduler for the NIF instead of working asynchronously
+
 ## v0.13.0 (2019-09-08)
 
 ### Compatability

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Ensure Rust is installed, then add Meeseeks to your `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:meeseeks, "~> 0.13.0"}
+    {:meeseeks, "~> 0.13.1"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meeseeks.Mixfile do
   use Mix.Project
 
-  @version "0.13.0"
+  @version "0.13.1"
 
   def project do
     [


### PR DESCRIPTION
### Enhancements

* [Parse] Update to `meeseeks_html5ever v0.12.1`, which uses a dirty scheduler for the NIF instead of working asynchronously