### PR TITLE
Remove incorrectly added whitespace when encoding comments to HTML

### DIFF
--- a/lib/meeseeks/document/comment.ex
+++ b/lib/meeseeks/document/comment.ex
@@ -7,7 +7,7 @@ defmodule Meeseeks.Document.Comment do
 
   @impl true
   def html(node, _document) do
-    "<!-- #{node.content} -->"
+    "<!--#{node.content}-->"
   end
 
   @impl true

--- a/test/meeseeks/document_test.exs
+++ b/test/meeseeks/document_test.exs
@@ -132,4 +132,12 @@ defmodule Meeseeks.DocumentTest do
       Document.children(@document, 9000)
     end
   end
+
+  test "comment survives round trip" do
+    original =
+      "<html><head><!-- test&%;><'\" - &quot; <script>alert(1)</script> --></head><body></body></html>"
+
+    result = original |> Meeseeks.parse() |> Meeseeks.html()
+    assert result == original
+  end
 end


### PR DESCRIPTION
I expect this negatively impacts literally no one ever, but `parse() |> html()` adds extra whitespace around comment text each time and I got upset about it.

```elixir
"<!-- hi -->" |> Meeseeks.parse() |> Meeseeks.html() |> Meeseeks.parse() |> Meeseeks.html()
"<!--   hi   -->..."
```

Floki doesn't do that, just sayin'
```elixir
"<!-- hi -->" |> Floki.parse() |> Floki.raw_html() |> Floki.parse() |> Floki.raw_html()
"<!-- hi -->"
```

Disclaimer: A major downside of this fix you have to write uglier manual tuple trees to output pretty comments. I understand if you decide this cost is too high.
```elixir
{:comment, "hi" } |> Meeseeks.parse(:tuple_tree) |> Meeseeks.html() 
"<!-- hi -->" # before, pretty
"<!--hi-->"   # after, not pretty

{:comment, " hi " } # not pretty, but correct
```