### PR TITLE
Update example to not use deprecated call

### DIFF
--- a/lib/meeseeks/document.ex
+++ b/lib/meeseeks/document.ex
@@ -23,7 +23,7 @@ defmodule Meeseeks.Document do
                         {"p", [], ["2"]},
                         {"p", [], ["3"]}]}]}]}
 
-  document = Meeseeks.Parser.parse(tuple_tree)
+  document = Meeseeks.Parser.parse(tuple_tree, :tuple_tree)
   #=> %Meeseeks.Document{
   #      id_counter: 12,
   #      roots: [1],


### PR DESCRIPTION
parse/1 with a tuple tree is deprecated. Please use parse/2 with the :tuple_tree type instead.