### PR TITLE
Prevent tuple tree parser from accepting invalid input

### DIFF
--- a/lib/meeseeks/extractor/helpers.ex
+++ b/lib/meeseeks/extractor/helpers.ex
@@ -64,19 +64,24 @@ defmodule Meeseeks.Extractor.Helpers do
 
   @whitespace_max_size 3
 
-  whitespace = List.flatten([
-    Enum.map(String.to_integer("0009", 16)..String.to_integer("000D", 16), fn int -> <<int::utf8>> end),
-    <<String.to_integer("0020", 16)::utf8>>,
-    <<String.to_integer("0085", 16)::utf8>>,
-    <<String.to_integer("00A0", 16)::utf8>>,
-    <<String.to_integer("1680", 16)::utf8>>,
-    Enum.map(String.to_integer("2000", 16)..String.to_integer("200A", 16), fn int -> <<int::utf8>> end),
-    <<String.to_integer("2028", 16)::utf8>>,
-    <<String.to_integer("2029", 16)::utf8>>,
-    <<String.to_integer("202F", 16)::utf8>>,
-    <<String.to_integer("205F", 16)::utf8>>,
-    <<String.to_integer("3000", 16)::utf8>>
-  ])
+  whitespace =
+    List.flatten([
+      Enum.map(String.to_integer("0009", 16)..String.to_integer("000D", 16), fn int ->
+        <<int::utf8>>
+      end),
+      <<String.to_integer("0020", 16)::utf8>>,
+      <<String.to_integer("0085", 16)::utf8>>,
+      <<String.to_integer("00A0", 16)::utf8>>,
+      <<String.to_integer("1680", 16)::utf8>>,
+      Enum.map(String.to_integer("2000", 16)..String.to_integer("200A", 16), fn int ->
+        <<int::utf8>>
+      end),
+      <<String.to_integer("2028", 16)::utf8>>,
+      <<String.to_integer("2029", 16)::utf8>>,
+      <<String.to_integer("202F", 16)::utf8>>,
+      <<String.to_integer("205F", 16)::utf8>>,
+      <<String.to_integer("3000", 16)::utf8>>
+    ])
 
   def ends_in_whitespace?(iodata)
   def ends_in_whitespace?(l) when is_list(l), do: list_ends_in_whitespace?(l)
@@ -93,6 +98,7 @@ defmodule Meeseeks.Extractor.Helpers do
   end
 
   defp bin_ends_in_whitespace?(""), do: false
+
   defp bin_ends_in_whitespace?(b) do
     bin_ends_in_whitespace?(b, byte_size(b))
   end

--- a/lib/meeseeks/tuple_tree.ex
+++ b/lib/meeseeks/tuple_tree.ex
@@ -1,7 +1,7 @@
 defmodule Meeseeks.TupleTree do
   @moduledoc """
   HTML documents in Elixir/Erlang have traditionally been represented by a
-  tuple-tree like:
+  tuple tree like:
 
   ```elixir
   {"html", [], [
@@ -10,22 +10,18 @@ defmodule Meeseeks.TupleTree do
       {"h1", [{"id", "greeting"}], ["Hello, World!"]}]}]}
   ```
 
-  `:mochiweb_html` parsed HTML into this format, and the tools for selecting
-  HTML used this format, so `html5ever` (the Elixir NIF) choose to output
-  to this format as well.
-
-  Meeseeks accepts tuple-trees as input, creating `Meeseeks.Document`s from
-  them.
+  To parse a tuple tree use `Meeseeks.parse(tuple_tree, :tuple_tree)`
   """
 
   @type comment :: {:comment, String.t()}
   @type doctype :: {:doctype, String.t(), String.t(), String.t()}
-  @type element :: {String.t(), [{String.t(), String.t()}], [node_t]}
+  @type element :: {String.t(), [{String.t(), String.t()}], [child_node_t]}
   @type processing_instruction ::
           {:pi, String.t()}
           | {:pi, String.t(), [{String.t(), String.t()}]}
           | {:pi, String.t(), String.t()}
   @type text :: String.t()
-  @type node_t :: comment | doctype | element | processing_instruction | text
-  @type t :: node_t | [node_t]
+  @type child_node_t :: comment | element | processing_instruction | text
+  @type root_node_t :: comment | doctype | element | processing_instruction
+  @type t :: root_node_t | [root_node_t]
 end

--- a/test/meeseeks/parser/tuple_tree_test.exs
+++ b/test/meeseeks/parser/tuple_tree_test.exs
@@ -1,7 +1,7 @@
 defmodule Meeseeks.Parser.TupleTreeTest do
   use ExUnit.Case
 
-  alias Meeseeks.{Error, Parser}
+  alias Meeseeks.{Document, Error, Parser}
 
   @tuple_tree [
     {:doctype, "html", "", ""},
@@ -23,23 +23,154 @@ defmodule Meeseeks.Parser.TupleTreeTest do
 
   @string "<!DOCTYPE html><html><head></head><body><div><p></p><p></p><div><p></p><p></p></div><p></p></div></body></html>"
 
-  test "tuple tree parser makes same document as string parser" do
+  test "creates same document as string parser" do
     assert Parser.parse(@tuple_tree, :tuple_tree) == Parser.parse(@string)
   end
 
-  @invalid_tuple_tree_root_node {:ok, {"html", [], []}}
-
-  test "tuple tree parser can't parse invalid root nodes" do
-    {:error, %Error{} = error} = Parser.parse(@invalid_tuple_tree_root_node, :tuple_tree)
+  test "cannot parse invalid root nodes" do
+    {:error, %Error{} = error} = Parser.parse({:ok, {"html", [], []}}, :tuple_tree)
     assert error.type == :parser
     assert error.reason == :invalid_input
-    assert error.metadata.description == "invalid tuple tree root node"
+    assert error.metadata.description == "invalid tuple tree node"
   end
 
-  @invalid_tuple_tree_node {"h1", [], [{:error, "NotANode"}]}
+  test "cannot parse invalid nodes" do
+    {:error, %Error{} = error} = Parser.parse({"h1", [], [{:error, "NotANode"}]}, :tuple_tree)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree node"
+  end
 
-  test "tuple tree parser can't parse invalid nodes" do
-    {:error, %Error{} = error} = Parser.parse(@invalid_tuple_tree_node, :tuple_tree)
+  # Comment
+
+  test "can parse valid comment node" do
+    assert match?(%Document{}, Parser.parse({:comment, "valid"}, :tuple_tree))
+  end
+
+  test "cannot parse comment node with invalid comment" do
+    {:error, %Error{} = error} = Parser.parse({:comment, :invalid}, :tuple_tree)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree node"
+  end
+
+  # Data
+
+  test "can parse valid data node" do
+    assert match?(%Document{}, Parser.parse({"script", [], ["valid"]}, :tuple_tree))
+  end
+
+  test "cannot parse data node with invalid data" do
+    {:error, %Error{} = error} = Parser.parse({"script", [], [:invalid]}, :tuple_tree)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree node"
+  end
+
+  # Doctype
+
+  test "can parse valid doctype node" do
+    assert match?(%Document{}, Parser.parse({:doctype, "valid", "valid", "valid"}, :tuple_tree))
+  end
+
+  test "cannot parse doctype node with invalid name" do
+    {:error, %Error{} = error} = Parser.parse({:doctype, :invalid, "valid", "valid"}, :tuple_tree)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree node"
+  end
+
+  test "cannot parse doctype node with invalid public" do
+    {:error, %Error{} = error} = Parser.parse({:doctype, "valid", :invalid, "valid"}, :tuple_tree)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree node"
+  end
+
+  test "cannot parse doctype node with invalid system" do
+    {:error, %Error{} = error} = Parser.parse({:doctype, "valid", "valid", :invalid}, :tuple_tree)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree node"
+  end
+
+  # Element
+
+  test "can parse valid element node" do
+    assert match?(%Document{}, Parser.parse({"valid", [{"valid", "valid"}], []}, :tuple_tree))
+  end
+
+  test "cannot parse element node with invalid tag" do
+    {:error, %Error{} = error} = Parser.parse({:invalid, [{"valid", "valid"}], []}, :tuple_tree)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree node"
+  end
+
+  test "cannot parse element node with invalid attribute" do
+    {:error, %Error{} = error} = Parser.parse({"valid", [{:invalid, "valid"}], []}, :tuple_tree)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree node"
+  end
+
+  test "cannot parse element node with invalid attribute value" do
+    {:error, %Error{} = error} = Parser.parse({"valid", [{"valid", :invalid}], []}, :tuple_tree)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree node"
+  end
+
+  test "cannot parse element node with invalid children" do
+    {:error, %Error{} = error} = Parser.parse({"valid", [{"valid", "valid"}], nil}, :tuple_tree)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree node"
+  end
+
+  # ProcessingInstruction
+
+  test "can parse valid two element processing instruction node" do
+    assert match?(%Document{}, Parser.parse({:pi, "php valid"}, :tuple_tree))
+  end
+
+  test "cannot parse two element processing instruction node with invalid data" do
+    {:error, %Error{} = error} = Parser.parse({:pi, "invalid"}, :tuple_tree)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree node"
+  end
+
+  test "can parse valid three element processing instruction node with data" do
+    assert match?(%Document{}, Parser.parse({:pi, "valid", "valid"}, :tuple_tree))
+  end
+
+  test "can parse valid three element processing instruction node with attributes" do
+    assert match?(%Document{}, Parser.parse({:pi, "valid", [{"valid", "valid"}]}, :tuple_tree))
+  end
+
+  test "cannot parse three element processing instruction node with invalid target" do
+    {:error, %Error{} = error} = Parser.parse({:pi, :invalid, "valid"}, :tuple_tree)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree node"
+  end
+
+  test "cannot parse three element processing instruction node invalid data" do
+    {:error, %Error{} = error} = Parser.parse({:pi, "valid", :invalid}, :tuple_tree)
+    assert error.type == :parser
+    assert error.reason == :invalid_input
+    assert error.metadata.description == "invalid tuple tree node"
+  end
+
+  # Text
+
+  test "can parse valid text node" do
+    assert match?(%Document{}, Parser.parse({"div", [], ["valid"]}, :tuple_tree))
+  end
+
+  test "cannot parse text node with invalid text" do
+    {:error, %Error{} = error} = Parser.parse({"div", [], [:invalid]}, :tuple_tree)
     assert error.type == :parser
     assert error.reason == :invalid_input
     assert error.metadata.description == "invalid tuple tree node"


### PR DESCRIPTION
PR for issue #74.

Tightens up the tuple tree parser to prevent the creation of an invalid document.

- Improves tuple tree spec
- Better guards against invalid input when parsing tuple trees