### PR TITLE
Don't use `Meeseeks.Parser` in docs (it's private)

### DIFF
--- a/lib/meeseeks/document.ex
+++ b/lib/meeseeks/document.ex
@@ -23,7 +23,7 @@ defmodule Meeseeks.Document do
                         {"p", [], ["2"]},
                         {"p", [], ["3"]}]}]}]}
 
-  document = Meeseeks.Parser.parse(tuple_tree, :tuple_tree)
+  document = Meeseeks.parse(tuple_tree, :tuple_tree)
   #=> %Meeseeks.Document{
   #      id_counter: 12,
   #      roots: [1],


### PR DESCRIPTION
The `Meeseeks.Parser.parse` function isn't documented