### PR TITLE
Expose `Meeseeks.Parser` module so types are visible to docs

### DIFF
--- a/lib/meeseeks/parser.ex
+++ b/lib/meeseeks/parser.ex
@@ -1,5 +1,5 @@
 defmodule Meeseeks.Parser do
-  @moduledoc false
+  @moduledoc "Parsing utilities."
 
   alias Meeseeks.{Document, Error, TupleTree}
   alias Meeseeks.Document.{Comment, Data, Doctype, Element, ProcessingInstruction, Text}
@@ -8,6 +8,8 @@ defmodule Meeseeks.Parser do
   @type type :: :html | :xml | :tuple_tree
 
   # Parse
+  
+  @doc false
 
   @spec parse(source) :: Document.t() | {:error, Error.t()}
 
@@ -33,6 +35,8 @@ defmodule Meeseeks.Parser do
 
     parse(tuple_tree, :tuple_tree)
   end
+  
+  @doc false
 
   @spec parse(source, type) :: Document.t() | {:error, Error.t()}
 


### PR DESCRIPTION
Currently, the `Meeseeks.Parser` module is private (`@moduledoc false`) which means that it's not possible for users to determine the proper parameters to (e.g.) `Meeseeks.parse/2` by looking at the docs (as they refer to an undocumented module).

(If you don't find this approach appropriate, I'm happy to rework the PR. Also I apologize for the branch names, and having submitted 2 PRs instead of a single one: I've made these changes in the GitHub UI and haven't found how to rename & merged the branches within GitHub. But I can also fix that if you'd prefer more meaningful branch names.)