### PR TITLE
Fix example tuple tree

### DIFF
--- a/lib/meeseeks/tuple_tree.ex
+++ b/lib/meeseeks/tuple_tree.ex
@@ -5,7 +5,7 @@ defmodule Meeseeks.TupleTree do
 
   ```elixir
   {"html", [], [
-    {"head", [], []}
+    {"head", [], []},
     {"body", [], [
       {"h1", [{"id", "greeting"}], ["Hello, World!"]}]}]}
   ```


### PR DESCRIPTION
Due to the missing comma, the example wasn't a valid Elixir list.