### PR TITLE
Prohibit XPath attribute steps outside of predicates

### DIFF
--- a/guides/xpath_selectors.md
+++ b/guides/xpath_selectors.md
@@ -4,7 +4,7 @@
 
 ### No top-level filter expressions
 
-Due to the way Meeseeks selection works, top-level filter expressions like `xpath("(//ol|//ul)[2]")`, which would select the second list element in the document, are particularly difficult to implement. An error will be raised if you try to use the above or any other top-level filter expression.
+Due to the way selection works, top-level filter expressions like `xpath("(//ol|//ul)[2]")`, which would select the second list element in the document, are particularly difficult to implement. An error will be raised if you try to use the above or any other top-level filter expression.
 
 To do the above try something like:
 
@@ -13,6 +13,19 @@ Meeseeks.all(doc, xpath("ol|ul")) |> Enum.at(1)
 ```
 
 All other filter expressions, like `xpath("//div[2]")`, are valid.
+
+### No attribute steps outside of predicates
+
+Due both to how selection works and how attributes are represented in documents (stored as part of an element, rather than as a separate node) there is no easy way to implement attribute selection, and use of attributes steps are prohibited outside of predicates and will raise an error.
+
+For example, `xpath("//p[@class]")` which returns elements with class attributes is allowed, but `xpath("//p/@class")` which would return the class attributes themselves is prohibited.
+
+To extract a selected element's attribute use the `attr` extractor.
+
+```elixir
+Meeseeks.all(doc, xpath("//p[@class]"))
+|> Enum.map(&Meeseeks.attr(&1, "class"))
+```
 
 ### No support for variable references
 

--- a/lib/meeseeks/xpath.ex
+++ b/lib/meeseeks/xpath.ex
@@ -21,6 +21,25 @@ defmodule Meeseeks.XPath do
 
   All other filter expressions, like `xpath("//div[2]")`, are valid.
 
+  ### No attribute steps outside of predicates
+
+  Due both to how selection works and how attributes are represented in
+  documents (stored as part of an element, rather than as a separate node)
+  there is no easy way to implement attribute selection, and use of
+  attributes steps are prohibited outside of predicates and will raise an
+  error.
+
+  For example, `xpath("//p[@class]")` which returns elements with class
+  attributes is allowed, but `xpath("//p/@class")` which would return the
+  class attributes themselves is prohibited.
+
+  To extract a selected element's attribute use the `attr` extractor.
+
+  ```elixir
+  Meeseeks.all(doc, xpath("//p[@class]"))
+  |> Enum.map(&Meeseeks.attr(&1, "class"))
+  ```
+
   ### No support for variable references
 
   Variable references are not currently supported, meaning expression like

--- a/test/meeseeks/selector/xpath_test.exs
+++ b/test/meeseeks/selector/xpath_test.exs
@@ -306,15 +306,38 @@ defmodule Meeseeks.Selector.XPathTest do
   end
 
   test "abbreviated attribute selector" do
-    xpath = "@*"
+    xpath = "*[@*]"
 
-    expected = %Node{
-      combinator: %XPath.Combinator.Attributes{
-        selector: %Node{
+    expected = %Meeseeks.Selector.Element{
+      combinator: %Meeseeks.Selector.Combinator.Children{
+        selector: %Meeseeks.Selector.Element{
           combinator: nil,
-          selectors: [%XPath.Predicate{e: %Expr.AttributeNameTest{name: "*", namespace: nil}}]
+          filters: [
+            %Meeseeks.Selector.XPath.Predicate{
+              e: %Meeseeks.Selector.XPath.Expr.Predicate{
+                e: %Meeseeks.Selector.XPath.Expr.Path{
+                  steps: [
+                    %Meeseeks.Selector.XPath.Expr.Step{
+                      combinator: %Meeseeks.Selector.XPath.Combinator.Attributes{
+                        selector: nil
+                      },
+                      predicates: [
+                        %Meeseeks.Selector.XPath.Expr.AttributeNameTest{
+                          name: "*",
+                          namespace: nil
+                        }
+                      ]
+                    }
+                  ],
+                  type: :rel
+                }
+              }
+            }
+          ],
+          selectors: [%Meeseeks.Selector.Element.Tag{value: "*"}]
         }
       },
+      filters: nil,
       selectors: []
     }
 
@@ -380,6 +403,16 @@ defmodule Meeseeks.Selector.XPathTest do
 
     assert_raise Error,
                  ~r/XPath filter expressions are not supported outside of predicates/,
+                 fn ->
+                   XPath.compile_selectors(xpath)
+                 end
+  end
+
+  test "no attribute steps outside of predicates" do
+    xpath = "//@class"
+
+    assert_raise Error,
+                 ~r/XPath attribute steps are not supported outside of predicates/,
                  fn ->
                    XPath.compile_selectors(xpath)
                  end


### PR DESCRIPTION
PR for issue #85.

Due both to how selection works and how attributes are represented in documents (stored as part of an element, rather than as a separate node) there is no easy way to implement attribute selection, and use of attributes steps are prohibited outside of predicates and will raise an error.

For example, `xpath("\\p[@class]")` which returns elements with class attributes is allowed, but `xpath("\\p\@class")` which would return the class attributes themselves is prohibited.

To extract a selected element's attribute use the `attr` extractor.

```elixir
Meeseeks.all(doc, xpath("//p[@class]"))
|> Enum.map(&Meeseeks.attr(&1, "class"))
```