### PR TITLE
Support unicode characters in xpath

### DIFF
--- a/src/xpath_expression_parser.yrl
+++ b/src/xpath_expression_parser.yrl
@@ -430,7 +430,7 @@ predicate_expr(E) ->
 %% literal_expr
 literal_expr(X) ->
         #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.Literal',
-          value => list_to_binary(value(X))}.
+          value => unicode:characters_to_binary(value(X))}.
 
 %% number_expr
 number_expr(X) ->
@@ -473,19 +473,19 @@ negative_expr(E) ->
 name_test({'wildcard', _Line, _Wildcard}) ->
         #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NameTest',
           namespace => nil,
-          tag => list_to_binary("*")};
+          tag => unicode:characters_to_binary("*")};
 name_test({'prefix_test', _Line, Ns}) ->
         #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NameTest',
-          namespace => list_to_binary(Ns),
+          namespace => unicode:characters_to_binary(Ns),
           tag => nil};
 name_test({'name', _Line, {_All, [], N}}) ->
         #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NameTest',
           namespace => nil,
-          tag => list_to_binary(N)};
+          tag => unicode:characters_to_binary(N)};
 name_test({'name', _Line, {_All, Ns, N}}) ->
         #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NameTest',
-          namespace => list_to_binary(Ns),
-          tag => list_to_binary(N)};
+          namespace => unicode:characters_to_binary(Ns),
+          tag => unicode:characters_to_binary(N)};
 name_test(Else) ->
         Else.
 
@@ -493,34 +493,34 @@ name_test(Else) ->
 attribute_name_test({'wildcard', _Line, _Wildcard}) ->
         #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.AttributeNameTest',
           namespace => nil,
-          name => list_to_binary("*")};
+          name => unicode:characters_to_binary("*")};
 attribute_name_test({'prefix_test', _Line, Ns}) ->
         #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.AttributeNameTest',
-          namespace => list_to_binary(Ns),
+          namespace => unicode:characters_to_binary(Ns),
           name => nil};
 attribute_name_test({'name', _Line, {_All, [], N}}) ->
         #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.AttributeNameTest',
           namespace => nil,
-          name => list_to_binary(N)};
+          name => unicode:characters_to_binary(N)};
 attribute_name_test({'name', _Line, {_All, Ns, N}}) ->
         #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.AttributeNameTest',
-          namespace => list_to_binary(Ns),
-          name => list_to_binary(N)}.
+          namespace => unicode:characters_to_binary(Ns),
+          name => unicode:characters_to_binary(N)}.
 
 %% namespace_name_test
 namespace_name_test({'wildcard', _Line, _Wildcard}) ->
         #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NamespaceNameTest',
           namespace => nil,
-          name => list_to_binary("*")};
+          name => unicode:characters_to_binary("*")};
 namespace_name_test({'prefix_test', _Line, Ns}) ->
         #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NamespaceNameTest',
-          namespace => list_to_binary(Ns),
+          namespace => unicode:characters_to_binary(Ns),
           name => nil};
 namespace_name_test({'name', _Line, {_All, [], N}}) ->
         #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NamespaceNameTest',
           namespace => nil,
-          name => list_to_binary(N)};
+          name => unicode:characters_to_binary(N)};
 namespace_name_test({'name', _Line, {_All, Ns, N}}) ->
         #{'__struct__' => 'Elixir.Meeseeks.Selector.XPath.Expr.NamespaceNameTest',
-          namespace => list_to_binary(Ns),
-          name => list_to_binary(N)}.
+          namespace => unicode:characters_to_binary(Ns),
+          name => unicode:characters_to_binary(N)}.

--- a/test/meeseeks/xpath_test.exs
+++ b/test/meeseeks/xpath_test.exs
@@ -25,6 +25,17 @@ defmodule Meeseeks.XPath_Test do
             </html>
             """)
 
+  @unicode_document Meeseeks.Parser.parse("""
+                    <html>
+                      <head></head>
+                      <body>
+                        <div id="main">
+                          <p>胡麻油大好き</p>
+                        </div>
+                      </body>
+                    </html>
+                    """)
+
   test "absolute path single segment" do
     selector = xpath("/comment()")
     expected = [%Result{id: 1, document: @document}]
@@ -401,6 +412,12 @@ defmodule Meeseeks.XPath_Test do
     assert_raise Error, ~r/Type: :xpath_expression\n\n  Reason: :unknown_function/, fn ->
       Meeseeks.all(@document, selector)
     end
+  end
+
+  test "selects unicode text equal to '胡麻油大好き'" do
+    selector = xpath("p[text() = '胡麻油大好き']")
+    expected = [%Result{id: 8, document: @unicode_document}]
+    assert Meeseeks.all(@unicode_document, selector) == expected
   end
 
   # macro input tests


### PR DESCRIPTION
issue #95 

This PR aims to support unicode characters inside xpath expressions.
The error stacktrace pointed to `erlang:list_to_binary` not being able to handle
strings with Japanese characters. This PR switches `erlang:list_to_binary` for `unicode:characters_to_binary`.