### PR TITLE
Release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
-No changes from v0.15.0.
+No changes from v0.15.1.
+
+## v0.15.1 (2020-05-27)
+
+### Fixes
+
+  * [Select] Support unicode characters in XPath selectors
 
 ## v0.15.0 (2020-02-16)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Ensure Rust is installed, then add Meeseeks to your `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:meeseeks, "~> 0.15.0"}
+    {:meeseeks, "~> 0.15.1"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meeseeks.Mixfile do
   use Mix.Project
 
-  @version "0.15.0"
+  @version "0.15.1"
 
   def project do
     [


### PR DESCRIPTION
### Fixes

  * [Select] Support unicode characters in XPath selectors