### PR TITLE
Release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.16.1 (2021-10-20)
+
 ### Compatibility
 
   * Use `meeseeks_html5ever v0.13.1`, which supports compilation on Apple M1

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Ensure Rust is installed, then add Meeseeks to your `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:meeseeks, "~> 0.16.0"}
+    {:meeseeks, "~> 0.16.1"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meeseeks.Mixfile do
   use Mix.Project
 
-  @version "0.16.0"
+  @version "0.16.1"
 
   def project do
     [


### PR DESCRIPTION
### Compatibility

* Use `meeseeks_html5ever v0.13.1`, which supports compilation on Apple M1