### PR TITLE
Release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.17.0 (2023-03-27)
+
 ### Compatibility
 
   * No longer support Elixir versions under 1.12 or Erlang/OTP versions under 23.0

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To install Meeseeks, add it to your `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:meeseeks, "~> 0.16.1"}
+    {:meeseeks, "~> 0.17.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Meeseeks.Mixfile do
   """
 
   @source_url "https://github.com/mischov/meeseeks"
-  @version "0.16.1"
+  @version "0.17.0"
 
   def project do
     [


### PR DESCRIPTION
### Compatibility

  * No longer support Elixir versions under 1.12 or Erlang/OTP versions under 23.0
  * Support Elixir 1.13 and 1.14 and Erlang/OTP 25.0

### Enhancements

  * Update to `meeseeks_html5ever v0.14.3`, which supports NIF precompilation