### PR TITLE
Release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## v0.18.0 (2025-06-01)
+
+### Compatibility
+
+  * No longer support Elixir versions under 1.16 or Erlang/OTP versions under 26.0
+  * Support Elixir 1.16, 1.17, and 1.18 as well as Erlang/OTP 26.0 and 27.0
+
 ## v0.17.0 (2023-03-27)
 
 ### Compatibility

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To install Meeseeks, add it to your `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:meeseeks, "~> 0.17.0"}
+    {:meeseeks, "~> 0.18.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Meeseeks.Mixfile do
   """
 
   @source_url "https://github.com/mischov/meeseeks"
-  @version "0.17.0"
+  @version "0.18.0"
 
   def project do
     [


### PR DESCRIPTION
### Compatibility

  * No longer support Elixir versions under 1.16 or Erlang/OTP versions under 26.0
  * Support Elixir 1.16, 1.17, and 1.18 as well as Erlang/OTP 26.0 and 27.0